### PR TITLE
Fix publish pipeline permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4
@@ -34,6 +34,7 @@ jobs:
     environment: pypi
     permissions:
       id-token: write
+      contents: read
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add `contents: read` permission to the publish job — the checkout step was failing with "repository not found" because specifying only `id-token: write` denied the default `contents: read`
- Expand Python test matrix in both CI and publish workflows to include 3.13 and 3.14

## Test plan
- [x] Re-tag v0.2.0 and verify the publish workflow passes checkout
- [x] Confirm tests run across all four Python versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)