### PR TITLE
feat: web visualizer for runs/ directory (sia web)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,18 +70,25 @@ Full provider/model reference: [docs/configuration.md](docs/configuration.md#api
 
 ### Run
 
+The CLI has two sub-commands: **`sia run`** (the self-improvement loop) and
+**`sia web`** (the runs visualizer, see [Visualize runs](#visualize-runs)).
+
 ```bash
-sia --task gpqa --max_gen 5 --run_id 1
+sia run --task gpqa --max_gen 5 --run_id 1
 ```
 
-Swap `--task` for any of the four bundled tasks.
+Swap `--task` for any of the four bundled tasks. (`sia --task ...` without the
+`run` sub-command still works and is treated as `sia run ...`.)
 
 Artifacts land in `runs/run_{run_id}/gen_{n}/`:
 - `target_agent.py` — the agent for that generation
 - `agent_execution.json` — execution logs
 - `improvement.md` — diff rationale (gen 2+)
 
-### Common flags
+While a run is in progress a **live dashboard** auto-starts at
+`http://127.0.0.1:8000` (requires the `web` extra; disable with `--no-web`).
+
+### Common flags (`sia run`)
 
 | Flag | Default | Description |
 |---|---|---|
@@ -91,16 +98,41 @@ Artifacts land in `runs/run_{run_id}/gen_{n}/`:
 | `--run_id` | 1 | Unique run identifier |
 | `--meta-profile` | `default-meta` | Profile for the meta/feedback agent (name or path to a `.json`) |
 | `--target-profile` | `default-target` | Profile for the target agent (name or path to a `.json`) |
+| `--no-web` | off | Don't auto-start the live dashboard during the run |
+| `--web-port` | 8000 | Port for the live dashboard (`--web-host` to change the bind host) |
 
 The model, backend, and provider for each agent come from a **profile** (see below). For example,
 to evaluate Kimi-K2.6 on Nebius as the target model:
 
 ```bash
 export NEBIUS_API_KEY="..."        # + ANTHROPIC_API_KEY for the default meta agent
-sia --task gpqa --target-profile kimi-nebius --max_gen 5 --run_id 2
+sia run --task gpqa --target-profile kimi-nebius --max_gen 5 --run_id 2
 ```
 
 Full backend, model, and API-key reference: [docs/configuration.md](docs/configuration.md). Hit a snag? [docs/troubleshooting.md](docs/troubleshooting.md).
+
+### Visualize runs
+
+A built-in web dashboard renders everything under `runs/`: the per-generation
+target-agent code (syntax-highlighted), meta/feedback prompts, improvement
+plans, evaluation scores (with an accuracy-across-generations chart and
+per-domain breakdown), execution trajectories, and logs.
+
+```bash
+pip install 'sia-agent[web]'
+sia web                          # serve ./runs at http://127.0.0.1:8000
+sia web --runs-dir ./runs --port 8080
+```
+
+It also starts automatically alongside `sia run` (disable with `--no-web`), so
+you can watch generations land live.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--runs-dir` | `./runs` | Directory of runs to visualize |
+| `--host` | `127.0.0.1` | Bind host |
+| `--port` | 8000 | Bind port |
+| `--no-browser` | off | Don't open a browser window automatically |
 
 ### Author your own profile
 
@@ -137,8 +169,8 @@ mkdir -p providers profiles
 
 ```bash
 export MY_ENDPOINT_API_KEY="..."
-sia --task gpqa --target-profile my-target          # by name (resolves ./profiles/my-target.json)
-sia --task gpqa --target-profile ./profiles/my-target.json   # or by explicit path
+sia run --task gpqa --target-profile my-target      # by name (resolves ./profiles/my-target.json)
+sia run --task gpqa --target-profile ./profiles/my-target.json   # or by explicit path
 ```
 
 To run the **meta/feedback** agent elsewhere, give a profile a real backend (`openhands` or
@@ -164,17 +196,43 @@ my-task/
 ```
 
 ```bash
-sia --task_dir ./my-task --max_gen 5 --run_id 1
+sia run --task_dir ./my-task --max_gen 5 --run_id 1
 ```
 
 **Or bring an MLE-Bench competition.** SIA can bootstrap a task directory directly from any [MLE-Bench](https://github.com/openai/mle-bench) competition — it pulls the dataset via the Kaggle API, sets up the public/private split, and drops in the reference agent template:
 
 ```bash
 python -m sia.prepare_mlebench_dataset -c "spaceship-titanic"
-sia --task_dir ./tasks/spaceship-titanic --max_gen 5 --run_id 1
+sia run --task_dir ./tasks/spaceship-titanic --max_gen 5 --run_id 1
 ```
 
 Full step-by-step for both paths: [docs/walkthrough.md](docs/walkthrough.md).
+
+---
+
+## Evaluation
+
+After every generation the orchestrator scores the target agent automatically and
+feeds the result into the next generation's feedback prompt — this is the signal
+the self-improvement loop optimizes against.
+
+1. The target agent writes its output into the generation directory (e.g. `gen_1/submission.csv`).
+2. The orchestrator runs the task's evaluator: `python evaluate.py --gen-dir gen_1/`.
+3. `evaluate.py` scores the output against the held-out ground truth in `data/private/`
+   and writes `gen_1/results.json` (or `evaluation_results.json`).
+4. Those metrics are injected into the feedback prompt and surfaced in `context.md`
+   and the [web dashboard](#visualize-runs) (accuracy-across-generations chart, per-domain breakdown).
+
+The four bundled tasks already ship an evaluator. For a **custom task**, drop an
+`evaluate.py` exposing an `evaluate()` function into `data/public/` — it decides the
+submission format, compares against `data/private/`, and returns a metrics dict.
+Test it standalone before a full run:
+
+```bash
+python my-task/data/public/evaluate.py --gen-dir runs/run_1/gen_1   # should write results.json
+```
+
+Full contract, return-format rules, and a complete example: [EVALUATION_GUIDE.md](EVALUATION_GUIDE.md).
 
 ---
 
@@ -183,6 +241,7 @@ Full step-by-step for both paths: [docs/walkthrough.md](docs/walkthrough.md).
 - [docs/architecture.md](docs/architecture.md) — directory layout, generation flow, prompt customization
 - [docs/walkthrough.md](docs/walkthrough.md) — detailed custom-task walkthrough
 - [docs/configuration.md](docs/configuration.md) — backends, models, API keys, CLI reference
+- [EVALUATION_GUIDE.md](EVALUATION_GUIDE.md) — writing `evaluate.py` for a custom task
 - [docs/troubleshooting.md](docs/troubleshooting.md) — common errors and fixes
 
 ## Citation

--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ plans, evaluation scores (with an accuracy-across-generations chart and
 per-domain breakdown), execution trajectories, and logs.
 
 ```bash
-pip install 'sia-agent[web]'
 sia web                          # serve ./runs at http://127.0.0.1:8000
 sia web --runs-dir ./runs --port 8080
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -168,10 +168,9 @@ Each run lands in its own `runs/run_{id}/` directory, so they can be compared si
 `sia web` serves a dashboard over the `runs/` directory: per-generation
 target-agent code (syntax-highlighted), meta/feedback prompts, improvement
 plans, evaluation scores (accuracy-across-generations chart + per-domain
-breakdown), execution trajectories, and logs. Install the extra first:
+breakdown), execution trajectories, and logs.
 
 ```bash
-pip install 'sia-agent[web]'
 sia web                                  # serve ./runs at http://127.0.0.1:8000
 sia web --runs-dir ./runs --port 8080    # custom directory / port
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,6 +4,12 @@ Full reference for SIA's agent **profiles**, **providers**, and command-line arg
 
 ## Command-line arguments
 
+SIA has two sub-commands: **`sia run`** (the self-improvement loop) and **`sia web`**
+(the runs visualizer, see [Visualizing runs](#visualizing-runs)). For backward
+compatibility, `sia <flags>` with no sub-command is treated as `sia run <flags>`.
+
+### `sia run`
+
 | Argument | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `--task` | one of | — | Name of a bundled task: `gpqa`, `lawbench`, `longcot-chess`, `spaceship-titanic` |
@@ -13,6 +19,18 @@ Full reference for SIA's agent **profiles**, **providers**, and command-line arg
 | `--meta-profile` | no | `default-meta` | Profile for the meta/feedback agent (name or path to a `.json`) |
 | `--target-profile` | no | `default-target` | Profile for the target agent (name or path to a `.json`) |
 | `--sandbox` | no | `none` | Target-agent isolation: `none` or `docker` |
+| `--no-web` | no | off | Don't auto-start the live dashboard during the run |
+| `--web-host` | no | `127.0.0.1` | Bind host for the live dashboard |
+| `--web-port` | no | `8000` | Bind port for the live dashboard |
+
+### `sia web`
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `--runs-dir` | no | `./runs` | Directory of runs to visualize |
+| `--host` | no | `127.0.0.1` | Bind host |
+| `--port` | no | `8000` | Bind port |
+| `--no-browser` | no | off | Don't open a browser window automatically |
 
 There are two agent roles, each selected by a profile:
 
@@ -76,8 +94,8 @@ Otherwise a bare **name** resolves in order:
 Add your own by dropping a JSON file in `./providers/` or `./profiles/` (no code change):
 
 ```bash
-sia --task gpqa --target-profile kimi-nebius          # bundled name
-sia --task gpqa --target-profile ./profiles/mine.json # explicit path
+sia run --task gpqa --target-profile kimi-nebius          # bundled name
+sia run --task gpqa --target-profile ./profiles/mine.json # explicit path
 ```
 
 ## Running
@@ -85,7 +103,7 @@ sia --task gpqa --target-profile ./profiles/mine.json # explicit path
 ### Default (Claude target, Claude meta)
 
 ```bash
-sia --task gpqa --max_gen 5 --run_id 1
+sia run --task gpqa --max_gen 5 --run_id 1
 ```
 
 Claude model shortcuts (used by the `claude` backend and `claude-*` target models):
@@ -97,7 +115,7 @@ Claude model shortcuts (used by the `claude` backend and `claude-*` target model
 ```bash
 export NEBIUS_API_KEY="..."        # target provider
 export ANTHROPIC_API_KEY="..."     # default-meta agent
-sia --task gpqa --target-profile kimi-nebius --max_gen 5 --run_id 2
+sia run --task gpqa --target-profile kimi-nebius --max_gen 5 --run_id 2
 ```
 
 The meta-agent refactors the task's reference agent to call the `openai` SDK at the Nebius
@@ -116,7 +134,7 @@ provider is rejected at load time). To run the meta agent elsewhere, author a pr
 ```
 
 ```bash
-sia --task gpqa --meta-profile gemini-meta
+sia run --task gpqa --meta-profile gemini-meta
 ```
 
 Backend model-spec conventions: OpenHands uses fully-qualified `provider/model`
@@ -139,11 +157,29 @@ export NEBIUS_API_KEY="..."      # nebius provider
 ## Comparing multiple LLMs on the same task
 
 ```bash
-sia --task gpqa --max_gen 3 --run_id 1 --target-profile default-target   # Claude
-sia --task gpqa --max_gen 3 --run_id 2 --target-profile kimi-nebius      # Kimi on Nebius
+sia run --task gpqa --max_gen 3 --run_id 1 --target-profile default-target   # Claude
+sia run --task gpqa --max_gen 3 --run_id 2 --target-profile kimi-nebius      # Kimi on Nebius
 ```
 
 Each run lands in its own `runs/run_{id}/` directory, so they can be compared side by side.
+
+## Visualizing runs
+
+`sia web` serves a dashboard over the `runs/` directory: per-generation
+target-agent code (syntax-highlighted), meta/feedback prompts, improvement
+plans, evaluation scores (accuracy-across-generations chart + per-domain
+breakdown), execution trajectories, and logs. Install the extra first:
+
+```bash
+pip install 'sia-agent[web]'
+sia web                                  # serve ./runs at http://127.0.0.1:8000
+sia web --runs-dir ./runs --port 8080    # custom directory / port
+```
+
+The same dashboard auto-starts in a background thread during `sia run` so you can
+watch generations land live; pass `--no-web` to disable it, or `--web-port` /
+`--web-host` to change where it binds. If the `web` extra isn't installed, the
+run logs a warning and continues without the dashboard.
 
 ## Environment-variable defaults
 

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -43,20 +43,20 @@ Create `my-tasks/gpqa/reference/SAMPLE_TASK_DESCRIPTIONS.md` with examples of si
 External custom task:
 
 ```bash
-sia --task_dir ./my-tasks/gpqa --max_gen 5 --run_id 1
+sia run --task_dir ./my-tasks/gpqa --max_gen 5 --run_id 1
 ```
 
 Bundled task (for comparison):
 
 ```bash
-sia --task gpqa --max_gen 5 --run_id 1
+sia run --task gpqa --max_gen 5 --run_id 1
 ```
 
 With a meta agent on OpenHands + Gemini (author `./profiles/gemini-meta.json` with
 `"backend": "openhands"`, `"model": "gemini/gemini-3.1-pro-preview"`, `"provider_id": "gemini"`):
 
 ```bash
-sia \
+sia run \
   --task_dir ./my-tasks/gpqa \
   --max_gen 5 \
   --run_id 1 \
@@ -77,6 +77,15 @@ cat runs/run_1/gen_2/improvement.md
 # Diff successive agent versions
 diff runs/run_1/gen_1/target_agent.py runs/run_1/gen_2/target_agent.py
 ```
+
+Or browse it all in the web dashboard (`pip install 'sia-agent[web]'`):
+
+```bash
+sia web                  # → http://127.0.0.1:8000
+```
+
+The dashboard also auto-starts during `sia run`, so you can watch generations
+land live (disable with `--no-web`).
 
 ## Task directory requirements
 

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -78,7 +78,7 @@ cat runs/run_1/gen_2/improvement.md
 diff runs/run_1/gen_1/target_agent.py runs/run_1/gen_2/target_agent.py
 ```
 
-Or browse it all in the web dashboard (`pip install 'sia-agent[web]'`):
+Or browse it all in the web dashboard:
 
 ```bash
 sia web                  # → http://127.0.0.1:8000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ claude = ["claude-agent-sdk>=0.1.50"]
 openhands = ["openhands-ai>=1.6.0"]
 pydantic-ai = ["pydantic-ai>=1.0"]
 mlebench = ["google-generativeai>=0.8"]
+web = ["fastapi>=0.110", "uvicorn>=0.29"]
 dev = [
     "pytest>=7.0",
     "ruff>=0.11",
@@ -52,6 +53,7 @@ include = ["sia*"]
 "sia" = [
     "defaults/providers/*.json",
     "defaults/profiles/*.json",
+    "web/static/*",
 ]
 "sia.tasks" = [
     "_shared/*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sia-agent"
-version = "0.2.1"
+version = "0.3.0"
 description = "SIA: Self-Improving AI framework"
 readme = "README.md"
 license = "MIT"
@@ -26,6 +26,9 @@ dependencies = [
     "numpy>=2.0",
     "pandas>=2.0",
     "scikit-learn>=1.4",
+    "fastapi>=0.110",
+    "uvicorn>=0.29",
+    "pydantic>=2.0",
 ]
 
 [project.optional-dependencies]
@@ -33,7 +36,6 @@ claude = ["claude-agent-sdk>=0.1.50"]
 openhands = ["openhands-ai>=1.6.0"]
 pydantic-ai = ["pydantic-ai>=1.0"]
 mlebench = ["google-generativeai>=0.8"]
-web = ["fastapi>=0.110", "uvicorn>=0.29"]
 dev = [
     "pytest>=7.0",
     "ruff>=0.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ mlebench = ["google-generativeai>=0.8"]
 dev = [
     "pytest>=7.0",
     "ruff>=0.11",
+    "httpx>=0.27",  # required by fastapi's TestClient (starlette.testclient)
 ]
 
 [project.scripts]

--- a/sia/backends/openhands.py
+++ b/sia/backends/openhands.py
@@ -49,7 +49,7 @@ async def run_agent_openhands(model_name, max_turns, prompt, agent_working_direc
 
     try:
         # Determine API key + base_url. An explicit provider takes precedence; otherwise
-        # fall back to inferring the key from the model name (original behavior).
+        # infer the key from the model name.
         base_url = provider.base_url if provider else None
         api_key = os.getenv(provider.api_key_env) if provider else resolve_api_key(model_name)
         if not api_key:

--- a/sia/cli.py
+++ b/sia/cli.py
@@ -1,7 +1,15 @@
 """Command-line argument parsing and resolution for the SIA orchestrator.
 
 Extracted from orchestrator.main() so the parser and the arg→params resolution
-can be tested independently. main() remains the entry point and calls into here.
+can be tested independently. main() remains the entry point and dispatches on the
+sub-command (``run`` / ``web``).
+
+Sub-commands:
+    sia run [flags]   Run the orchestrator (agent evolution). This is the default
+                      when no sub-command is given, so ``sia --task gpqa`` still
+                      works. A live dashboard is started in a background thread
+                      unless ``--no-web`` is passed.
+    sia web [flags]   Serve the runs visualizer over HTTP.
 
 Agent configuration is selected via JSON *profiles* (see sia/profiles.py): the
 meta/feedback agent via ``--meta-profile`` and the target agent via ``--target-profile``.
@@ -13,15 +21,16 @@ from __future__ import annotations
 import argparse
 
 from sia.config import Config
-from sia.layout import BUNDLED_TASKS
+from sia.layout import BUNDLED_TASKS, Names
 from sia.logging_setup import get_logger
 
 logger = get_logger(__name__)
 
+_SUBCOMMANDS = ("run", "web")
 
-def build_parser(env_config: Config) -> argparse.ArgumentParser:
-    """Build the orchestrator argument parser (defaults come from env_config)."""
-    parser = argparse.ArgumentParser(description="Run the orchestrator for agent evolution")
+
+def _add_run_args(parser: argparse.ArgumentParser, env_config: Config) -> None:
+    """Attach orchestrator (agent-evolution) arguments to ``parser``."""
     parser.add_argument(
         "--max_gen",
         type=int,
@@ -78,9 +87,84 @@ def build_parser(env_config: Config) -> argparse.ArgumentParser:
         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
         help="Logging verbosity (default: INFO, or the $SIA_LOG_LEVEL env var).",
     )
+    # Live dashboard controls (the web server auto-started during a run).
+    parser.add_argument(
+        "--no-web",
+        dest="no_web",
+        action="store_true",
+        help="Do not start the live visualizer dashboard during the run.",
+    )
+    parser.add_argument(
+        "--web-port",
+        dest="web_port",
+        type=int,
+        default=8000,
+        help="Port for the live dashboard started during the run (default: 8000).",
+    )
+    parser.add_argument(
+        "--web-host",
+        dest="web_host",
+        type=str,
+        default="127.0.0.1",
+        help="Host for the live dashboard (default: 127.0.0.1).",
+    )
+
+
+def _add_web_args(parser: argparse.ArgumentParser, env_config: Config) -> None:
+    """Attach visualizer (``sia web``) arguments to ``parser``."""
+    parser.add_argument("--host", type=str, default="127.0.0.1", help="Bind host (default: 127.0.0.1).")
+    parser.add_argument("--port", type=int, default=8000, help="Bind port (default: 8000).")
+    parser.add_argument(
+        "--runs-dir",
+        dest="runs_dir",
+        type=str,
+        default=Names.RUNS_ROOT,
+        help=f"Directory of runs to visualize (default: {Names.RUNS_ROOT}).",
+    )
+    parser.add_argument(
+        "--no-browser",
+        dest="no_browser",
+        action="store_true",
+        help="Do not open a browser window automatically.",
+    )
+    parser.add_argument(
+        "--log-level",
+        dest="log_level",
+        type=str,
+        default=None,
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Logging verbosity (default: INFO, or the $SIA_LOG_LEVEL env var).",
+    )
+
+
+def build_parser(env_config: Config) -> argparse.ArgumentParser:
+    """Build the top-level ``sia`` parser with ``run`` / ``web`` sub-commands."""
+    parser = argparse.ArgumentParser(prog="sia", description="SIA: Self-Improving AI framework")
+    sub = parser.add_subparsers(dest="command", metavar="{run,web}")
+
+    run_parser = sub.add_parser("run", help="Run the orchestrator (agent evolution).")
+    _add_run_args(run_parser, env_config)
+
+    web_parser = sub.add_parser("web", help="Serve the runs visualizer over HTTP.")
+    _add_web_args(web_parser, env_config)
+
     return parser
 
 
 def parse_args(env_config: Config, argv: list[str] | None = None) -> argparse.Namespace:
-    """Parse CLI arguments using env_config-derived defaults."""
-    return build_parser(env_config).parse_args(argv)
+    """Parse CLI arguments, defaulting to the ``run`` sub-command.
+
+    For backward compatibility ``sia --task gpqa`` (no sub-command) is treated as
+    ``sia run --task gpqa``; ``sia web ...`` opts into the visualizer.
+    """
+    import sys
+
+    raw = sys.argv[1:] if argv is None else argv
+    # Insert the default sub-command unless the user asked for one (or for help).
+    if not raw or (raw[0] not in _SUBCOMMANDS and raw[0] not in ("-h", "--help")):
+        raw = ["run", *raw]
+
+    args = build_parser(env_config).parse_args(raw)
+    if args.command is None:
+        args.command = "run"
+    return args

--- a/sia/config.py
+++ b/sia/config.py
@@ -16,7 +16,7 @@ class Config:
     DEFAULT_META_PROFILE: str = "default-meta"
     DEFAULT_TARGET_PROFILE: str = "default-target"
 
-    # Model defaults (legacy; retained as fallbacks for context metadata / env overrides)
+    # Model defaults (fallbacks for context metadata / env overrides)
     DEFAULT_CLAUDE_META_MODEL: str = "haiku"
     DEFAULT_OPENHANDS_META_MODEL: str = "gemini/gemini-3.1-pro-preview"
     DEFAULT_TASK_MODEL: str = "claude-haiku-4-5-20251001"

--- a/sia/context_manager.py
+++ b/sia/context_manager.py
@@ -14,7 +14,6 @@ from typing import Any
 
 from sia.config import Config
 
-# Used internally below and re-exported under their historical private names for tests.
 from sia.io_utils import safe_load_json as _safe_load_json
 from sia.io_utils import safe_read_file as _safe_read_file
 from sia.logging_setup import get_logger

--- a/sia/context_manager.py
+++ b/sia/context_manager.py
@@ -13,7 +13,6 @@ from datetime import datetime
 from typing import Any
 
 from sia.config import Config
-
 from sia.io_utils import safe_load_json as _safe_load_json
 from sia.io_utils import safe_read_file as _safe_read_file
 from sia.logging_setup import get_logger

--- a/sia/io_utils.py
+++ b/sia/io_utils.py
@@ -17,7 +17,7 @@ from sia.logging_setup import get_logger
 
 logger = get_logger(__name__)
 
-# Default size cap, evaluated once at import (equivalent to the previous class-attr default).
+# Default size cap, evaluated once at import.
 _DEFAULT_MAX_BYTES = Config().MAX_CONTEXT_FILE_SIZE
 
 

--- a/sia/layout.py
+++ b/sia/layout.py
@@ -103,8 +103,7 @@ class RunLayout:
     def for_run_id(cls, run_id: int, runs_root: str = Names.RUNS_ROOT) -> RunLayout:
         return cls(f"{runs_root}/run_{run_id}")
 
-    # Generation directories. orchestrator uses absolute paths; context_manager
-    # historically uses relative joins. Both are preserved (do not unify).
+    # Generation directories: gen_dir returns an absolute path, gen_dir_rel a relative one.
     def gen_dir(self, n: int) -> str:
         return os.path.abspath(f"{self.run_dir}/gen_{n}")
 

--- a/sia/orchestrator.py
+++ b/sia/orchestrator.py
@@ -688,9 +688,16 @@ def run_generation(
         logger.info(f"Generation {current_gen} is the final generation. Skipping feedback agent.")
 
 
+def _run_web(args) -> None:
+    """Dispatch for ``sia web``: serve the runs visualizer in the foreground."""
+    configure_logging(args.log_level)
+    from sia.web import serve
+
+    serve(host=args.host, port=args.port, runs_dir=args.runs_dir, open_browser=not args.no_browser)
+
+
 def main():
     configure_logging()
-    _print_welcome()
 
     # Load env-var overrides (lower priority than explicit CLI flags)
     env_config = Config.from_env()
@@ -698,8 +705,20 @@ def main():
     # Parse command-line arguments
     args = cli.parse_args(env_config)
 
+    if args.command == "web":
+        _run_web(args)
+        return
+
+    _print_welcome()
+
     # Apply CLI log level (overrides the import-time default / $SIA_LOG_LEVEL).
     configure_logging(args.log_level)
+
+    # Start the live dashboard in a background thread so the run is watchable.
+    if not args.no_web:
+        from sia.web import serve_in_background
+
+        serve_in_background(host=args.web_host, port=args.web_port, runs_dir=Names.RUNS_ROOT)
 
     max_gen = args.max_gen
     task_dir, shared_dir = resolve_task_dir(args.task, args.task_dir)

--- a/sia/orchestrator.py
+++ b/sia/orchestrator.py
@@ -697,6 +697,7 @@ def _run_web(args) -> None:
 
 def main():
     configure_logging()
+    _print_welcome()
 
     # Load env-var overrides (lower priority than explicit CLI flags)
     env_config = Config.from_env()
@@ -707,8 +708,6 @@ def main():
     if args.command == "web":
         _run_web(args)
         return
-
-    _print_welcome()
 
     # Apply CLI log level (overrides the import-time default / $SIA_LOG_LEVEL).
     configure_logging(args.log_level)

--- a/sia/orchestrator.py
+++ b/sia/orchestrator.py
@@ -63,7 +63,6 @@ from sia.results import FeedbackContext, TargetAgentResult
 from sia.run_setup import RunSetup, TaskFiles, load_task_files, setup_run_directory
 from sia.util import run_agent
 
-# Re-exported for the existing test/public-import contract (and used internally).
 __all__ = [
     "BUNDLED_TASKS",
     "RunSetup",
@@ -108,7 +107,7 @@ def load_agent_execution(gen_directory, config: Config | None = None):
     execution_folder = os.path.join(gen_directory, Names.AGENT_EXECUTION_DIR)
     execution_file = os.path.join(gen_directory, Names.AGENT_EXECUTION_JSON)
 
-    # Check for multi-trajectory folder first (new format)
+    # Multi-trajectory folder: one file per question
     if os.path.isdir(execution_folder):
         logger.info("  → Detected multi-trajectory format (folder)")
 
@@ -140,7 +139,7 @@ def load_agent_execution(gen_directory, config: Config | None = None):
 
         return {"trajectories": trajectories, "count": len(trajectories), "type": "multi-trajectory"}, True
 
-    # Fall back to single file (old format, backwards compatible)
+    # Single combined execution file
     elif os.path.exists(execution_file):
         logger.info("  → Detected single-file format")
 

--- a/sia/web/__init__.py
+++ b/sia/web/__init__.py
@@ -1,0 +1,11 @@
+"""Web visualizer for the SIA ``runs/`` directory.
+
+Public surface:
+    create_app(runs_dir)          -> FastAPI app
+    serve(...)                    -> run in foreground (``sia web``)
+    serve_in_background(...)      -> daemon thread (live dashboard during ``sia run``)
+"""
+
+from sia.web.server import create_app, serve, serve_in_background
+
+__all__ = ["create_app", "serve", "serve_in_background"]

--- a/sia/web/runs.py
+++ b/sia/web/runs.py
@@ -405,9 +405,7 @@ def list_openhands_sessions(runs_root: Path, run_name: str, gen_name: str) -> li
     return sorted(child.name for child in root.iterdir() if child.is_dir())
 
 
-def get_openhands_events(
-    runs_root: Path, run_name: str, gen_name: str, session: str
-) -> list[dict[str, Any]] | None:
+def get_openhands_events(runs_root: Path, run_name: str, gen_name: str, session: str) -> list[dict[str, Any]] | None:
     gen_dir = _resolve_gen(runs_root, run_name, gen_name)
     if gen_dir is None:
         return None

--- a/sia/web/runs.py
+++ b/sia/web/runs.py
@@ -1,0 +1,458 @@
+"""Data layer for the runs visualizer.
+
+Pure, dependency-light functions that read the ``runs/`` directory tree and turn
+it into JSON-serializable models. Nothing here imports FastAPI, so it can be
+unit-tested in isolation and reused from other tools.
+
+Directory shape this understands (see orchestrator.py for the writer side)::
+
+    runs/
+      run_<id>/
+        context.md                 # run-level metadata + per-generation log
+        gen_<n>/
+          target_agent.py          # the generated agent code
+          meta_agent_prompt.txt     # gen 1: the meta-agent prompt
+          feedback_agent_prompt.txt # gen >1: the feedback prompt
+          improvement.md            # gen >1: the improvement plan
+          evaluation_results.json   # scores + per-question details
+          evaluation.log            # evaluator stdout/stderr
+          target_agent_stdout.log   # agent stdout
+          agent_execution/          # execution_q<id>.json per-question chat logs
+          openhands_trajectory/     # <session>/events/event-*.json (optional)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel
+
+# Files we surface as first-class artifacts in the UI (label -> filename).
+TEXT_ARTIFACTS: dict[str, str] = {
+    "target_agent": "target_agent.py",
+    "meta_prompt": "meta_agent_prompt.txt",
+    "feedback_prompt": "feedback_agent_prompt.txt",
+    "improvement": "improvement.md",
+    "eval_log": "evaluation.log",
+    "stdout_log": "target_agent_stdout.log",
+}
+
+# Candidate names for the structured evaluation summary, in priority order.
+_EVAL_RESULT_NAMES = ("evaluation_results.json", "results.json")
+
+_RUN_DIR_RE = re.compile(r"^run_(\d+)$")
+_GEN_DIR_RE = re.compile(r"^gen_(\d+)$")
+_EXEC_FILE_RE = re.compile(r"^execution_q(\d+)\.json$")
+_META_RE = re.compile(r"^\*\*(?P<key>[^*]+)\*\*:\s*(?P<value>.*)$")
+
+
+# --------------------------------------------------------------------------- #
+# Models
+# --------------------------------------------------------------------------- #
+class EvalSummary(BaseModel):
+    """Headline numbers from a generation's evaluation results."""
+
+    total: int | None = None
+    correct: int | None = None
+    incorrect: int | None = None
+    missing: int | None = None
+    invalid: int | None = None
+    accuracy_percent: float | None = None
+
+
+class GenerationSummary(BaseModel):
+    name: str
+    index: int
+    eval: EvalSummary | None = None
+    has_target_agent: bool = False
+    has_improvement: bool = False
+    num_trajectories: int = 0
+
+
+class RunSummary(BaseModel):
+    name: str
+    index: int
+    task: str | None = None
+    meta_model: str | None = None
+    task_model: str | None = None
+    backend: str | None = None
+    started: str | None = None
+    max_generations: int | None = None
+    num_generations: int = 0
+    best_accuracy_percent: float | None = None
+    generations: list[GenerationSummary] = []
+
+
+class DomainStat(BaseModel):
+    domain: str
+    total: int
+    correct: int
+    accuracy_percent: float
+
+
+class GenerationDetail(BaseModel):
+    name: str
+    index: int
+    eval: EvalSummary | None = None
+    domains: list[DomainStat] = []
+    artifacts: list[str] = []
+    trajectories: list[int] = []
+    has_openhands: bool = False
+
+
+class RunDetail(BaseModel):
+    name: str
+    index: int
+    task: str | None = None
+    meta_model: str | None = None
+    task_model: str | None = None
+    backend: str | None = None
+    started: str | None = None
+    max_generations: int | None = None
+    context_md: str | None = None
+    generations: list[GenerationDetail] = []
+
+
+# --------------------------------------------------------------------------- #
+# Filesystem helpers
+# --------------------------------------------------------------------------- #
+def _read_json(path: Path) -> Any | None:
+    try:
+        with path.open(encoding="utf-8") as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _read_text(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+
+def _eval_results_path(gen_dir: Path) -> Path | None:
+    for name in _EVAL_RESULT_NAMES:
+        candidate = gen_dir / name
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _eval_summary(gen_dir: Path) -> EvalSummary | None:
+    path = _eval_results_path(gen_dir)
+    if path is None:
+        return None
+    data = _read_json(path)
+    if not isinstance(data, dict):
+        return None
+    pct = data.get("accuracy_percent")
+    if pct is None and isinstance(data.get("accuracy"), int | float):
+        pct = data["accuracy"] * 100
+    return EvalSummary(
+        total=data.get("total_questions") or data.get("total"),
+        correct=data.get("correct"),
+        incorrect=data.get("incorrect"),
+        missing=data.get("missing"),
+        invalid=data.get("invalid"),
+        accuracy_percent=pct,
+    )
+
+
+def _trajectory_ids(gen_dir: Path) -> list[int]:
+    exec_dir = gen_dir / "agent_execution"
+    if not exec_dir.is_dir():
+        return []
+    ids: list[int] = []
+    for child in exec_dir.iterdir():
+        m = _EXEC_FILE_RE.match(child.name)
+        if m:
+            ids.append(int(m.group(1)))
+    return sorted(ids)
+
+
+def _gen_dirs(run_dir: Path) -> list[tuple[int, Path]]:
+    found: list[tuple[int, Path]] = []
+    for child in run_dir.iterdir():
+        if not child.is_dir():
+            continue
+        m = _GEN_DIR_RE.match(child.name)
+        if m:
+            found.append((int(m.group(1)), child))
+    return sorted(found, key=lambda t: t[0])
+
+
+def parse_context_md(text: str) -> dict[str, str]:
+    """Extract the leading ``**Key**: value`` metadata block from context.md."""
+    meta: dict[str, str] = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("## "):  # first generation heading => end of header block
+            break
+        m = _META_RE.match(line)
+        if m:
+            meta[m.group("key").strip().lower()] = m.group("value").strip()
+    return meta
+
+
+# --------------------------------------------------------------------------- #
+# Public API
+# --------------------------------------------------------------------------- #
+def list_runs(runs_root: Path) -> list[RunSummary]:
+    """Summaries for every ``run_<id>`` directory, newest id first."""
+    if not runs_root.is_dir():
+        return []
+    runs: list[RunSummary] = []
+    for child in runs_root.iterdir():
+        m = _RUN_DIR_RE.match(child.name) if child.is_dir() else None
+        if m:
+            runs.append(_run_summary(child, int(m.group(1))))
+    runs.sort(key=lambda r: r.index, reverse=True)
+    return runs
+
+
+def _run_summary(run_dir: Path, index: int) -> RunSummary:
+    meta: dict[str, str] = {}
+    context = run_dir / "context.md"
+    if context.is_file():
+        meta = parse_context_md(_read_text(context) or "")
+
+    gens: list[GenerationSummary] = []
+    best: float | None = None
+    for gen_index, gen_dir in _gen_dirs(run_dir):
+        ev = _eval_summary(gen_dir)
+        gens.append(
+            GenerationSummary(
+                name=gen_dir.name,
+                index=gen_index,
+                eval=ev,
+                has_target_agent=(gen_dir / TEXT_ARTIFACTS["target_agent"]).is_file(),
+                has_improvement=(gen_dir / TEXT_ARTIFACTS["improvement"]).is_file(),
+                num_trajectories=len(_trajectory_ids(gen_dir)),
+            )
+        )
+        if ev and ev.accuracy_percent is not None:
+            best = ev.accuracy_percent if best is None else max(best, ev.accuracy_percent)
+
+    return RunSummary(
+        name=run_dir.name,
+        index=index,
+        task=meta.get("task"),
+        meta_model=meta.get("meta model"),
+        task_model=meta.get("task model"),
+        backend=meta.get("backend"),
+        started=meta.get("started"),
+        max_generations=_as_int(meta.get("max generations")),
+        num_generations=len(gens),
+        best_accuracy_percent=best,
+        generations=gens,
+    )
+
+
+def get_run(runs_root: Path, run_name: str) -> RunDetail | None:
+    run_dir = _safe_child(runs_root, run_name)
+    if run_dir is None or not run_dir.is_dir():
+        return None
+    m = _RUN_DIR_RE.match(run_dir.name)
+    if not m:
+        return None
+
+    meta: dict[str, str] = {}
+    context_md: str | None = None
+    context = run_dir / "context.md"
+    if context.is_file():
+        context_md = _read_text(context)
+        meta = parse_context_md(context_md or "")
+
+    generations = [_generation_detail(gen_dir, gi) for gi, gen_dir in _gen_dirs(run_dir)]
+
+    return RunDetail(
+        name=run_dir.name,
+        index=int(m.group(1)),
+        task=meta.get("task"),
+        meta_model=meta.get("meta model"),
+        task_model=meta.get("task model"),
+        backend=meta.get("backend"),
+        started=meta.get("started"),
+        max_generations=_as_int(meta.get("max generations")),
+        context_md=context_md,
+        generations=generations,
+    )
+
+
+def _generation_detail(gen_dir: Path, index: int) -> GenerationDetail:
+    artifacts = [label for label, fname in TEXT_ARTIFACTS.items() if (gen_dir / fname).is_file()]
+    return GenerationDetail(
+        name=gen_dir.name,
+        index=index,
+        eval=_eval_summary(gen_dir),
+        domains=_domain_stats(gen_dir),
+        artifacts=artifacts,
+        trajectories=_trajectory_ids(gen_dir),
+        has_openhands=(gen_dir / "openhands_trajectory").is_dir(),
+    )
+
+
+def _domain_stats(gen_dir: Path) -> list[DomainStat]:
+    path = _eval_results_path(gen_dir)
+    data = _read_json(path) if path else None
+    if not isinstance(data, dict):
+        return []
+    details = data.get("details")
+    if not isinstance(details, list):
+        return []
+    buckets: dict[str, list[int]] = {}  # domain -> [total, correct]
+    for row in details:
+        if not isinstance(row, dict):
+            continue
+        domain = str(row.get("domain") or "Unknown")
+        bucket = buckets.setdefault(domain, [0, 0])
+        bucket[0] += 1
+        if row.get("is_correct"):
+            bucket[1] += 1
+    stats = [
+        DomainStat(
+            domain=domain,
+            total=total,
+            correct=correct,
+            accuracy_percent=(correct / total * 100) if total else 0.0,
+        )
+        for domain, (total, correct) in buckets.items()
+    ]
+    stats.sort(key=lambda s: s.domain)
+    return stats
+
+
+def get_eval_details(runs_root: Path, run_name: str, gen_name: str) -> list[dict[str, Any]] | None:
+    """The full per-question ``details`` array from evaluation results."""
+    gen_dir = _resolve_gen(runs_root, run_name, gen_name)
+    if gen_dir is None:
+        return None
+    path = _eval_results_path(gen_dir)
+    data = _read_json(path) if path else None
+    if isinstance(data, dict) and isinstance(data.get("details"), list):
+        return data["details"]
+    return None
+
+
+def get_artifact_text(runs_root: Path, run_name: str, gen_name: str, label: str) -> str | None:
+    """Read one of the known text artifacts (by label, not raw path)."""
+    fname = TEXT_ARTIFACTS.get(label)
+    gen_dir = _resolve_gen(runs_root, run_name, gen_name)
+    if fname is None or gen_dir is None:
+        return None
+    return _read_text(gen_dir / fname)
+
+
+def get_trajectory(runs_root: Path, run_name: str, gen_name: str, qid: int) -> list[dict[str, str]] | None:
+    """Per-question chat log, normalized to ``[{role, text}]`` turns."""
+    gen_dir = _resolve_gen(runs_root, run_name, gen_name)
+    if gen_dir is None:
+        return None
+    path = gen_dir / "agent_execution" / f"execution_q{qid}.json"
+    data = _read_json(path)
+    if not isinstance(data, list):
+        return None
+    return [_normalize_turn(msg) for msg in data if isinstance(msg, dict)]
+
+
+def _normalize_turn(msg: dict[str, Any]) -> dict[str, str]:
+    role = str(msg.get("role", "unknown"))
+    content = msg.get("content")
+    if isinstance(content, str):
+        text = content
+    elif isinstance(content, list):
+        text = "\n\n".join(_block_text(block) for block in content).strip()
+    else:
+        text = "" if content is None else str(content)
+    return {"role": role, "text": text}
+
+
+def _block_text(block: Any) -> str:
+    if isinstance(block, str):
+        return block
+    if not isinstance(block, dict):
+        return str(block)
+    btype = block.get("type")
+    if btype == "text" or "text" in block:
+        return str(block.get("text", ""))
+    if btype == "tool_use":
+        args = json.dumps(block.get("input", {}), indent=2)
+        return f"[tool_use: {block.get('name', '?')}]\n{args}"
+    if btype == "tool_result":
+        return f"[tool_result]\n{_stringify(block.get('content'))}"
+    return _stringify(block)
+
+
+def _stringify(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return "\n".join(_block_text(v) for v in value)
+    return json.dumps(value, indent=2, default=str)
+
+
+def list_openhands_sessions(runs_root: Path, run_name: str, gen_name: str) -> list[str] | None:
+    gen_dir = _resolve_gen(runs_root, run_name, gen_name)
+    if gen_dir is None:
+        return None
+    root = gen_dir / "openhands_trajectory"
+    if not root.is_dir():
+        return []
+    return sorted(child.name for child in root.iterdir() if child.is_dir())
+
+
+def get_openhands_events(
+    runs_root: Path, run_name: str, gen_name: str, session: str
+) -> list[dict[str, Any]] | None:
+    gen_dir = _resolve_gen(runs_root, run_name, gen_name)
+    if gen_dir is None:
+        return None
+    session_dir = _safe_child(gen_dir / "openhands_trajectory", session)
+    if session_dir is None or not session_dir.is_dir():
+        return None
+    events_dir = session_dir / "events"
+    if not events_dir.is_dir():
+        return []
+    events: list[dict[str, Any]] = []
+    for child in sorted(events_dir.iterdir()):
+        if child.suffix == ".json":
+            data = _read_json(child)
+            if isinstance(data, dict):
+                events.append(data)
+    return events
+
+
+# --------------------------------------------------------------------------- #
+# Path safety
+# --------------------------------------------------------------------------- #
+def _safe_child(parent: Path, name: str) -> Path | None:
+    """Resolve ``parent/name`` and refuse anything that escapes ``parent``."""
+    if not name or "/" in name or "\\" in name or name in (".", ".."):
+        return None
+    try:
+        resolved = (parent / name).resolve()
+        resolved.relative_to(parent.resolve())
+    except (OSError, ValueError):
+        return None
+    return resolved
+
+
+def _resolve_gen(runs_root: Path, run_name: str, gen_name: str) -> Path | None:
+    run_dir = _safe_child(runs_root, run_name)
+    if run_dir is None or not _RUN_DIR_RE.match(run_name):
+        return None
+    gen_dir = _safe_child(run_dir, gen_name)
+    if gen_dir is None or not _GEN_DIR_RE.match(gen_name) or not gen_dir.is_dir():
+        return None
+    return gen_dir
+
+
+def _as_int(value: str | None) -> int | None:
+    try:
+        return int(value) if value is not None else None
+    except ValueError:
+        return None

--- a/sia/web/server.py
+++ b/sia/web/server.py
@@ -25,8 +25,7 @@ def create_app(runs_dir: str | Path):
         from fastapi.responses import FileResponse, PlainTextResponse
     except ModuleNotFoundError as exc:  # pragma: no cover - import guard
         raise RuntimeError(
-            "The web visualizer needs FastAPI + uvicorn. Install with:\n"
-            "    pip install 'sia-agent[web]'"
+            "The web visualizer needs FastAPI + uvicorn. Install with:\n    pip install 'sia-agent[web]'"
         ) from exc
 
     runs_root = Path(runs_dir).resolve()

--- a/sia/web/server.py
+++ b/sia/web/server.py
@@ -1,0 +1,141 @@
+"""FastAPI app + launchers for the runs visualizer.
+
+``create_app(runs_dir)`` builds the app; ``serve(...)`` runs it in the
+foreground (the ``sia web`` command); ``serve_in_background(...)`` starts it in a
+daemon thread so the orchestrator can expose a live dashboard during ``sia run``.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+from sia.logging_setup import get_logger
+from sia.web import runs as runs_data
+
+logger = get_logger(__name__)
+
+_STATIC_DIR = Path(__file__).parent / "static"
+
+
+def create_app(runs_dir: str | Path):
+    """Build the FastAPI application serving the runs under ``runs_dir``."""
+    try:
+        from fastapi import FastAPI, HTTPException
+        from fastapi.responses import FileResponse, PlainTextResponse
+    except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+        raise RuntimeError(
+            "The web visualizer needs FastAPI + uvicorn. Install with:\n"
+            "    pip install 'sia-agent[web]'"
+        ) from exc
+
+    runs_root = Path(runs_dir).resolve()
+    app = FastAPI(title="SIA Runs Visualizer", docs_url="/api/docs", openapi_url="/api/openapi.json")
+
+    @app.get("/api/runs")
+    def api_runs():
+        return runs_data.list_runs(runs_root)
+
+    @app.get("/api/runs/{run_name}")
+    def api_run(run_name: str):
+        detail = runs_data.get_run(runs_root, run_name)
+        if detail is None:
+            raise HTTPException(status_code=404, detail=f"Run not found: {run_name}")
+        return detail
+
+    @app.get("/api/runs/{run_name}/gens/{gen_name}/eval")
+    def api_eval_details(run_name: str, gen_name: str):
+        details = runs_data.get_eval_details(runs_root, run_name, gen_name)
+        if details is None:
+            raise HTTPException(status_code=404, detail="No evaluation details found")
+        return details
+
+    @app.get("/api/runs/{run_name}/gens/{gen_name}/artifact/{label}", response_class=PlainTextResponse)
+    def api_artifact(run_name: str, gen_name: str, label: str):
+        text = runs_data.get_artifact_text(runs_root, run_name, gen_name, label)
+        if text is None:
+            raise HTTPException(status_code=404, detail=f"Artifact not found: {label}")
+        return text
+
+    @app.get("/api/runs/{run_name}/gens/{gen_name}/trajectory/{qid}")
+    def api_trajectory(run_name: str, gen_name: str, qid: int):
+        turns = runs_data.get_trajectory(runs_root, run_name, gen_name, qid)
+        if turns is None:
+            raise HTTPException(status_code=404, detail=f"Trajectory not found: q{qid}")
+        return turns
+
+    @app.get("/api/runs/{run_name}/gens/{gen_name}/openhands")
+    def api_openhands_sessions(run_name: str, gen_name: str):
+        sessions = runs_data.list_openhands_sessions(runs_root, run_name, gen_name)
+        if sessions is None:
+            raise HTTPException(status_code=404, detail="Generation not found")
+        return sessions
+
+    @app.get("/api/runs/{run_name}/gens/{gen_name}/openhands/{session}")
+    def api_openhands_events(run_name: str, gen_name: str, session: str):
+        events = runs_data.get_openhands_events(runs_root, run_name, gen_name, session)
+        if events is None:
+            raise HTTPException(status_code=404, detail="Session not found")
+        return events
+
+    @app.get("/")
+    def index():
+        return FileResponse(_STATIC_DIR / "index.html")
+
+    return app
+
+
+def serve(
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    runs_dir: str | Path = "./runs",
+    open_browser: bool = True,
+) -> None:
+    """Run the server in the foreground (blocks). Used by ``sia web``."""
+    import uvicorn
+
+    app = create_app(runs_dir)
+    url = f"http://{host}:{port}"
+    logger.info(f"SIA visualizer serving {Path(runs_dir).resolve()} at {url}")
+    if open_browser:
+        _open_browser_later(url)
+    uvicorn.run(app, host=host, port=port, log_level="warning")
+
+
+def serve_in_background(
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    runs_dir: str | Path = "./runs",
+) -> threading.Thread | None:
+    """Start the server in a daemon thread; never raises if deps are missing.
+
+    Returns the thread (or ``None`` if the server could not start). Intended to
+    give a live dashboard while ``sia run`` is executing.
+    """
+    try:
+        import uvicorn
+
+        app = create_app(runs_dir)
+    except (RuntimeError, ModuleNotFoundError) as exc:
+        logger.warning(f"Live dashboard unavailable: {exc}")
+        return None
+
+    config = uvicorn.Config(app, host=host, port=port, log_level="warning")
+    server = uvicorn.Server(config)
+
+    def _run() -> None:
+        try:
+            server.run()
+        except Exception as exc:  # pragma: no cover - background best-effort
+            logger.warning(f"Live dashboard stopped: {exc}")
+
+    thread = threading.Thread(target=_run, name="sia-web", daemon=True)
+    thread.start()
+    logger.info(f"Live dashboard: http://{host}:{port} (serving {Path(runs_dir).resolve()})")
+    return thread
+
+
+def _open_browser_later(url: str, delay: float = 1.0) -> None:
+    import webbrowser
+
+    threading.Timer(delay, lambda: webbrowser.open(url)).start()

--- a/sia/web/static/index.html
+++ b/sia/web/static/index.html
@@ -1,0 +1,506 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>SIA Runs Visualizer</title>
+<style>
+  :root {
+    --bg: #0f1115; --panel: #171a21; --panel-2: #1d212b; --border: #272c38;
+    --text: #e6e9ef; --muted: #8b93a7; --accent: #6ea8fe; --good: #4ade80;
+    --bad: #f87171; --warn: #fbbf24; --code-bg: #11141a;
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--text); font-family: var(--sans);
+    font-size: 14px; line-height: 1.5; }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .app { display: grid; grid-template-columns: 300px 1fr; height: 100vh; }
+  .sidebar { border-right: 1px solid var(--border); background: var(--panel);
+    overflow-y: auto; display: flex; flex-direction: column; }
+  .brand { padding: 16px 18px; border-bottom: 1px solid var(--border); display: flex;
+    align-items: center; gap: 10px; }
+  .brand h1 { font-size: 15px; margin: 0; letter-spacing: .5px; }
+  .brand .dot { width: 9px; height: 9px; border-radius: 50%; background: var(--good);
+    box-shadow: 0 0 8px var(--good); }
+  .runlist { padding: 8px; }
+  .run-item { display: block; padding: 10px 12px; border-radius: 8px; cursor: pointer;
+    border: 1px solid transparent; margin-bottom: 4px; }
+  .run-item:hover { background: var(--panel-2); }
+  .run-item.active { background: var(--panel-2); border-color: var(--accent); }
+  .run-item .top { display: flex; justify-content: space-between; align-items: center; }
+  .run-item .name { font-weight: 600; }
+  .run-item .sub { color: var(--muted); font-size: 12px; margin-top: 2px;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .main { overflow-y: auto; padding: 24px 28px; }
+  .badge { font-family: var(--mono); font-size: 12px; padding: 2px 8px; border-radius: 999px;
+    background: var(--panel-2); border: 1px solid var(--border); }
+  .badge.good { color: var(--good); border-color: #2c5; }
+  .badge.bad { color: var(--bad); }
+  .badge.warn { color: var(--warn); }
+  .meta-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px,1fr));
+    gap: 10px; margin: 12px 0 20px; }
+  .meta-card { background: var(--panel); border: 1px solid var(--border); border-radius: 10px;
+    padding: 9px 12px; }
+  .meta-card .k { color: var(--muted); font-size: 11px; text-transform: uppercase;
+    letter-spacing: .6px; }
+  .meta-card .v { margin-top: 4px; font-family: var(--mono); font-size: 13px; word-break: break-word; }
+  h2 { font-size: 18px; margin: 24px 0 8px; }
+  h3 { font-size: 15px; margin: 18px 0 8px; color: var(--muted); }
+  .tabs { display: flex; gap: 4px; border-bottom: 1px solid var(--border); margin: 8px 0 16px;
+    flex-wrap: wrap; }
+  .tab { padding: 8px 14px; cursor: pointer; border-radius: 8px 8px 0 0; color: var(--muted);
+    border: 1px solid transparent; border-bottom: none; }
+  .tab:hover { color: var(--text); }
+  .tab.active { color: var(--text); background: var(--panel); border-color: var(--border); }
+  pre { background: var(--code-bg); border: 1px solid var(--border); border-radius: 10px;
+    padding: 14px 16px; overflow-x: auto; font-family: var(--mono); font-size: 12.5px;
+    line-height: 1.55; white-space: pre-wrap; word-break: break-word; }
+  pre.nowrap { white-space: pre; word-break: normal; }
+  .t-c { color: #6b7280; font-style: italic; }  /* comment */
+  .t-s { color: #a5d6a7; }                       /* string  */
+  .t-n { color: #f0a868; }                       /* number  */
+  .t-k { color: #c792ea; }                       /* keyword */
+  .t-b { color: #82aaff; }                       /* builtin */
+  .t-d { color: #ffcb6b; }                       /* decorator */
+  .t-f { color: #82aaff; }                       /* def/class name */
+  table { border-collapse: collapse; width: 100%; font-size: 13px; }
+  th, td { text-align: left; padding: 7px 10px; border-bottom: 1px solid var(--border); }
+  th { color: var(--muted); font-weight: 600; position: sticky; top: 0; background: var(--bg); }
+  td.mono, th.mono { font-family: var(--mono); }
+  .ok { color: var(--good); } .no { color: var(--bad); }
+  .gen-chart { background: var(--panel); border: 1px solid var(--border); border-radius: 10px;
+    padding: 16px; margin: 8px 0 20px; }
+  .pill-row { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 12px; }
+  .pill { padding: 6px 12px; border-radius: 999px; cursor: pointer; background: var(--panel);
+    border: 1px solid var(--border); color: var(--muted); }
+  .pill.active { color: var(--text); border-color: var(--accent); }
+  .bar { height: 8px; background: var(--panel-2); border-radius: 4px; overflow: hidden; }
+  .bar > span { display: block; height: 100%; background: var(--accent); }
+  .muted { color: var(--muted); }
+  .turn { border: 1px solid var(--border); border-radius: 10px; margin-bottom: 10px;
+    overflow: hidden; }
+  .turn .role { padding: 6px 12px; font-family: var(--mono); font-size: 12px;
+    text-transform: uppercase; letter-spacing: .5px; }
+  .turn.system .role { background: #2a2440; color: #c4b5fd; }
+  .turn.user .role { background: #1e2a3a; color: #93c5fd; }
+  .turn.assistant .role { background: #1e3329; color: #86efac; }
+  .turn.tool .role, .turn.unknown .role { background: var(--panel-2); color: var(--muted); }
+  .turn .body { padding: 10px 14px; white-space: pre-wrap; font-family: var(--mono);
+    font-size: 12.5px; }
+  .empty { color: var(--muted); padding: 40px; text-align: center; }
+  .md h1,.md h2,.md h3 { color: var(--text); }
+  .md code { background: var(--code-bg); padding: 1px 5px; border-radius: 4px; font-family: var(--mono); }
+  .md ul { padding-left: 22px; }
+  .toolbar { display: flex; align-items: center; gap: 10px; margin-bottom: 10px; flex-wrap: wrap; }
+  select, input { background: var(--panel-2); color: var(--text); border: 1px solid var(--border);
+    border-radius: 8px; padding: 6px 10px; font-family: var(--sans); font-size: 13px; }
+  .crumbs { color: var(--muted); margin-bottom: 6px; font-size: 13px; }
+  .spinner { color: var(--muted); padding: 30px; }
+</style>
+</head>
+<body>
+<div class="app">
+  <aside class="sidebar">
+    <div class="brand"><span class="dot"></span><h1>SIA RUNS</h1></div>
+    <div class="runlist" id="runlist"><div class="spinner">Loading…</div></div>
+  </aside>
+  <main class="main" id="main"><div class="empty">Select a run from the left.</div></main>
+</div>
+
+<script>
+const $ = (sel, el=document) => el.querySelector(sel);
+const h = (tag, attrs={}, ...kids) => {
+  const el = document.createElement(tag);
+  for (const [k,v] of Object.entries(attrs)) {
+    if (k === "class") el.className = v;
+    else if (k === "html") el.innerHTML = v;
+    else if (k.startsWith("on") && typeof v === "function") el.addEventListener(k.slice(2), v);
+    else if (v !== null && v !== undefined) el.setAttribute(k, v);
+  }
+  for (const kid of kids.flat()) {
+    if (kid == null) continue;
+    el.append(kid.nodeType ? kid : document.createTextNode(kid));
+  }
+  return el;
+};
+const api = async (path) => {
+  const r = await fetch(path);
+  if (!r.ok) throw new Error(`${r.status} ${path}`);
+  const ct = r.headers.get("content-type") || "";
+  return ct.includes("application/json") ? r.json() : r.text();
+};
+const fmtPct = (p) => p == null ? "—" : p.toFixed(1) + "%";
+const pctClass = (p) => p == null ? "" : p >= 50 ? "good" : p >= 25 ? "warn" : "bad";
+const esc = (s) => (s ?? "").replace(/[&<>]/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;"}[c]));
+
+// Minimal, safe markdown (headings, bold, inline code, lists, hr, code fences).
+function md(src) {
+  const lines = (src || "").split("\n");
+  let out = "", inUl = false, inCode = false;
+  const closeUl = () => { if (inUl) { out += "</ul>"; inUl = false; } };
+  for (let raw of lines) {
+    if (raw.trim().startsWith("```")) {
+      if (inCode) { out += "</code></pre>"; inCode = false; }
+      else { closeUl(); out += "<pre><code>"; inCode = true; }
+      continue;
+    }
+    if (inCode) { out += esc(raw) + "\n"; continue; }
+    let line = esc(raw);
+    line = line.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+               .replace(/`([^`]+?)`/g, "<code>$1</code>")
+               .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
+    let m;
+    if (/^\s*---+\s*$/.test(raw)) { closeUl(); out += "<hr>"; }
+    else if ((m = line.match(/^(#{1,4})\s+(.*)$/))) { closeUl(); const n = m[1].length; out += `<h${n}>${m[2]}</h${n}>`; }
+    else if ((m = line.match(/^\s*[-*]\s+(.*)$/))) { if (!inUl) { out += "<ul>"; inUl = true; } out += `<li>${m[1]}</li>`; }
+    else if (line.trim() === "") { closeUl(); }
+    else { closeUl(); out += `<p>${line}</p>`; }
+  }
+  closeUl(); if (inCode) out += "</code></pre>";
+  return out;
+}
+
+// Minimal, dependency-free Python highlighter. Tokenizes with a single sticky
+// regex (priority order: comment, triple/quoted string, decorator, number,
+// identifier) so spans never overlap or break HTML escaping.
+const PY_KW = new Set(("False None True and as assert async await break class continue def del " +
+  "elif else except finally for from global if import in is lambda nonlocal not or pass raise " +
+  "return try while with yield match case self cls").split(" "));
+const PY_BUILTIN = new Set(("print len range int float str list dict set tuple bool bytes open " +
+  "enumerate zip map filter sum min max abs round sorted reversed type isinstance issubclass " +
+  "hasattr getattr setattr delattr super object property staticmethod classmethod repr format " +
+  "any all next iter input vars dir id hash hex oct bin chr ord Exception BaseException " +
+  "ValueError KeyError TypeError IndexError RuntimeError StopIteration FileNotFoundError " +
+  "NotImplementedError OSError IOError AttributeError ImportError True False None").split(" "));
+const PY_TOKEN = new RegExp(
+  "(#[^\\n]*)" +                                                            // 1 comment
+  "|([rbfuRBFU]{0,3}(?:'''[\\s\\S]*?'''|\"\"\"[\\s\\S]*?\"\"\"))" +          // 2 triple string
+  "|([rbfuRBFU]{0,3}(?:\"(?:\\\\.|[^\"\\\\\\n])*\"|'(?:\\\\.|[^'\\\\\\n])*'))" + // 3 string
+  "|(@[A-Za-z_][\\w.]*)" +                                                  // 4 decorator
+  "|(\\b\\d[\\w.]*\\b)" +                                                   // 5 number
+  "|([A-Za-z_]\\w*)" +                                                      // 6 identifier
+  "|(\\s+)" +                                                              // 7 whitespace
+  "|([^\\s])", "y");                                                        // 8 other
+
+function highlightPython(code) {
+  let out = "", pos = 0, afterDef = false;
+  const span = (cls, t) => `<span class="t-${cls}">${esc(t)}</span>`;
+  while (pos < code.length) {
+    PY_TOKEN.lastIndex = pos;
+    const m = PY_TOKEN.exec(code);
+    if (!m) { out += esc(code[pos]); pos++; continue; }
+    const [full, comment, tstr, str, dec, num, ident, ws] = m;
+    if (comment != null) { out += span("c", full); afterDef = false; }
+    else if (tstr != null || str != null) { out += span("s", full); afterDef = false; }
+    else if (dec != null) { out += span("d", full); afterDef = false; }
+    else if (num != null) { out += span("n", full); afterDef = false; }
+    else if (ident != null) {
+      if (PY_KW.has(full)) { out += span("k", full); afterDef = (full === "def" || full === "class"); }
+      else if (afterDef) { out += span("f", full); afterDef = false; }
+      else if (PY_BUILTIN.has(full)) { out += span("b", full); }
+      else { out += esc(full); }
+    }
+    else if (ws != null) { out += esc(ws); }   // whitespace preserves afterDef
+    else { out += esc(full); afterDef = false; }
+    pos = PY_TOKEN.lastIndex;
+  }
+  return out;
+}
+
+// ---- Routing (hash) ---------------------------------------------------------
+let RUNS = [];
+async function boot() {
+  try {
+    RUNS = await api("/api/runs");
+  } catch (e) { $("#runlist").innerHTML = `<div class="empty">Failed to load runs.<br>${esc(e.message)}</div>`; return; }
+  renderSidebar();
+  window.addEventListener("hashchange", route);
+  route();
+}
+
+function renderSidebar() {
+  const list = $("#runlist");
+  list.innerHTML = "";
+  if (!RUNS.length) { list.innerHTML = `<div class="empty">No runs found.</div>`; return; }
+  for (const r of RUNS) {
+    const p = r.best_accuracy_percent;
+    list.append(h("a", { class: "run-item", href: `#/${r.name}`, "data-run": r.name },
+      h("div", { class: "top" },
+        h("span", { class: "name" }, r.name),
+        h("span", { class: "badge " + pctClass(p) }, fmtPct(p))),
+      h("div", { class: "sub" }, `${r.backend || "?"} · ${r.task_model || r.meta_model || "?"} · ${r.num_generations} gen`)));
+  }
+  syncSidebarActive();
+}
+
+function syncSidebarActive() {
+  const active = currentRoute().run;
+  for (const item of document.querySelectorAll(".run-item"))
+    item.classList.toggle("active", item.getAttribute("data-run") === active);
+}
+
+function currentRoute() {
+  const parts = location.hash.replace(/^#\/?/, "").split("/").filter(Boolean);
+  return { run: parts[0], gen: parts[1], tab: parts[2] };
+}
+
+// Cache run details and track what's currently mounted so navigation only
+// re-renders the part that actually changed (no full-page flicker on tab clicks).
+const RUN_CACHE = {};
+const VIEW = { pillsRow: null, genHost: null, tabsBar: null, genBody: null };
+let MOUNTED = { run: null, gen: null, tab: null };
+
+async function route() {
+  const { run } = currentRoute();
+  syncSidebarActive();
+  if (!run) {
+    MOUNTED = { run: null, gen: null, tab: null };
+    $("#main").innerHTML = `<div class="empty">Select a run from the left.</div>`;
+    return;
+  }
+
+  let detail = RUN_CACHE[run];
+  if (!detail) {
+    if (MOUNTED.run !== run) $("#main").innerHTML = `<div class="spinner">Loading ${esc(run)}…</div>`;
+    try {
+      detail = RUN_CACHE[run] = await api(`/api/runs/${run}`);
+    } catch (e) {
+      MOUNTED = { run: null, gen: null, tab: null };
+      $("#main").innerHTML = `<div class="empty">Failed to load ${esc(run)}.<br>${esc(e.message)}</div>`;
+      return;
+    }
+  }
+
+  if (MOUNTED.run !== run) { renderRun(detail); MOUNTED = { run, gen: null, tab: null }; }
+  mountGen(detail);
+}
+
+// ---- Run view (static chrome: built once per run) ---------------------------
+function renderRun(run) {
+  const main = $("#main");
+  main.innerHTML = "";
+  main.append(h("div", { class: "crumbs" }, "runs / " + run.name));
+  main.append(h("h2", { style: "margin-bottom:2px" }, run.name));
+  if (run.started) main.append(h("div", { class: "muted", style: "font-size:12px;margin-bottom:8px" }, "Started " + run.started));
+
+  const metaItems = [
+    ["Backend", run.backend], ["Meta model", run.meta_model], ["Task model", run.task_model],
+    ["Task", run.task], ["Max generations", run.max_generations],
+  ];
+  main.append(h("div", { class: "meta-grid" },
+    metaItems.filter(([,v]) => v != null && v !== "").map(([k,v]) =>
+      h("div", { class: "meta-card" }, h("div", { class: "k" }, k), h("div", { class: "v" }, String(v))))));
+
+  main.append(genChart(run.generations));
+
+  VIEW.pillsRow = h("div", { class: "pill-row" });
+  VIEW.genHost = h("div", {});
+  main.append(VIEW.pillsRow, VIEW.genHost);
+}
+
+// ---- Generation mount: only re-render the bits that changed ------------------
+function mountGen(detail) {
+  const gens = detail.generations;
+  if (!gens.length) { VIEW.genHost.innerHTML = `<div class="empty">No generations yet.</div>`; return; }
+  const { gen, tab } = currentRoute();
+  const activeGen = gens.find(g => g.name === gen) || gens[gens.length - 1];
+  const activeTab = tab || "overview";
+
+  // Pills: cheap synchronous rebuild (preserves the active tab when switching gen).
+  VIEW.pillsRow.innerHTML = "";
+  for (const g of gens) {
+    VIEW.pillsRow.append(h("a", {
+      class: "pill" + (g.name === activeGen.name ? " active" : ""),
+      href: `#/${detail.name}/${g.name}/${activeTab}`,
+    }, `${g.name} · ${fmtPct(g.eval?.accuracy_percent)}`));
+  }
+
+  if (MOUNTED.gen !== activeGen.name) {
+    buildGenScaffold(detail, activeGen);
+    MOUNTED.gen = activeGen.name;
+    MOUNTED.tab = null;
+  }
+  if (MOUNTED.tab !== activeTab) {
+    showTab(detail, activeGen, activeTab);
+    MOUNTED.tab = activeTab;
+  }
+}
+
+function genChart(gens) {
+  const wrap = h("div", { class: "gen-chart" }, h("div", { class: "k muted" }, "ACCURACY ACROSS GENERATIONS"));
+  const pts = gens.map(g => ({ x: g.index, y: g.eval?.accuracy_percent }));
+  const W = 640, H = 160, pad = 28;
+  const maxY = Math.max(50, ...pts.map(p => p.y || 0));
+  const sx = (i) => pad + (gens.length <= 1 ? 0 : i * (W - 2*pad) / (gens.length - 1));
+  const sy = (y) => H - pad - (y || 0) / maxY * (H - 2*pad);
+  const ns = "http://www.w3.org/2000/svg";
+  const svg = document.createElementNS(ns, "svg");
+  svg.setAttribute("viewBox", `0 0 ${W} ${H}`); svg.setAttribute("width", "100%"); svg.style.maxWidth = W+"px";
+  // axis
+  const axis = document.createElementNS(ns, "line");
+  axis.setAttribute("x1", pad); axis.setAttribute("y1", H-pad); axis.setAttribute("x2", W-pad); axis.setAttribute("y2", H-pad);
+  axis.setAttribute("stroke", "#272c38"); svg.append(axis);
+  const valid = pts.filter(p => p.y != null);
+  if (valid.length >= 2) {
+    const poly = document.createElementNS(ns, "polyline");
+    poly.setAttribute("fill", "none"); poly.setAttribute("stroke", "#6ea8fe"); poly.setAttribute("stroke-width", "2");
+    poly.setAttribute("points", valid.map((p,i) => `${sx(gens.findIndex(g=>g.index===p.x))},${sy(p.y)}`).join(" "));
+    svg.append(poly);
+  }
+  pts.forEach((p, i) => {
+    if (p.y == null) return;
+    const c = document.createElementNS(ns, "circle");
+    c.setAttribute("cx", sx(i)); c.setAttribute("cy", sy(p.y)); c.setAttribute("r", 4); c.setAttribute("fill", "#6ea8fe");
+    svg.append(c);
+    const t = document.createElementNS(ns, "text");
+    t.setAttribute("x", sx(i)); t.setAttribute("y", sy(p.y) - 9); t.setAttribute("fill", "#e6e9ef");
+    t.setAttribute("font-size", "11"); t.setAttribute("text-anchor", "middle"); t.textContent = p.y.toFixed(1) + "%";
+    svg.append(t);
+    const lbl = document.createElementNS(ns, "text");
+    lbl.setAttribute("x", sx(i)); lbl.setAttribute("y", H-pad+16); lbl.setAttribute("fill", "#8b93a7");
+    lbl.setAttribute("font-size", "11"); lbl.setAttribute("text-anchor", "middle"); lbl.textContent = "gen " + p.x;
+    svg.append(lbl);
+  });
+  wrap.append(svg);
+  return wrap;
+}
+
+// ---- Generation view --------------------------------------------------------
+const GEN_TABS = [
+  ["overview", "Overview"], ["code", "Agent code"], ["prompt", "Prompt"],
+  ["improvement", "Improvement"], ["trajectories", "Trajectories"], ["logs", "Logs"],
+];
+
+// Build the tabs bar + empty body container once per generation. The tabs bar
+// persists across tab clicks so only the body swaps (no flicker of the chrome).
+function buildGenScaffold(run, gen) {
+  VIEW.genHost.innerHTML = "";
+  VIEW.tabsBar = h("div", { class: "tabs" }, GEN_TABS.map(([id, label]) =>
+    h("a", { class: "tab", "data-tab": id, href: `#/${run.name}/${gen.name}/${id}` }, label)));
+  VIEW.genBody = h("div", {});
+  VIEW.genHost.append(VIEW.tabsBar, VIEW.genBody);
+}
+
+const TAB_RENDERERS = {
+  overview: tabOverview, code: tabCode, prompt: tabPrompt,
+  improvement: tabImprovement, trajectories: tabTrajectories, logs: tabLogs,
+};
+
+function showTab(run, gen, tab) {
+  for (const el of VIEW.tabsBar.children)
+    el.classList.toggle("active", el.getAttribute("data-tab") === tab);
+  VIEW.genBody.innerHTML = "";
+  (TAB_RENDERERS[tab] || tabOverview)({ run, gen, body: VIEW.genBody });
+}
+
+function tabOverview({ gen, body }) {
+  const ev = gen.eval;
+  if (ev) {
+    body.append(h("div", { class: "meta-grid" },
+      [["Accuracy", fmtPct(ev.accuracy_percent)], ["Correct", ev.correct], ["Incorrect", ev.incorrect],
+       ["Total", ev.total], ["Missing", ev.missing], ["Invalid", ev.invalid]]
+      .filter(([,v]) => v != null).map(([k,v]) =>
+        h("div", { class: "meta-card" }, h("div", { class: "k" }, k), h("div", { class: "v" }, String(v))))));
+  } else {
+    body.append(h("div", { class: "muted" }, "No evaluation results for this generation."));
+  }
+  if (gen.domains?.length) {
+    body.append(h("h3", {}, "By domain"));
+    const t = h("table", {}, h("thead", {}, h("tr", {},
+      h("th", {}, "Domain"), h("th", {}, "Accuracy"), h("th", {}, "Correct / Total"), h("th", { style:"width:30%" }, ""))));
+    const tb = h("tbody", {});
+    for (const d of gen.domains) {
+      tb.append(h("tr", {},
+        h("td", {}, d.domain),
+        h("td", { class: "mono " + (d.accuracy_percent>=50?"ok":d.accuracy_percent>=25?"":"no") }, fmtPct(d.accuracy_percent)),
+        h("td", { class: "mono" }, `${d.correct} / ${d.total}`),
+        h("td", {}, h("div", { class: "bar" }, h("span", { style: `width:${d.accuracy_percent}%` })))));
+    }
+    t.append(tb); body.append(t);
+  }
+}
+
+async function tabCode({ run, gen, body }) {
+  if (!gen.artifacts.includes("target_agent")) { body.append(h("div", { class:"muted" }, "No target_agent.py.")); return; }
+  body.append(h("div", { class: "spinner" }, "Loading code…"));
+  const code = await api(`/api/runs/${run.name}/gens/${gen.name}/artifact/target_agent`);
+  body.innerHTML = "";
+  body.append(h("div", { class:"toolbar" }, h("span", { class:"muted" }, "target_agent.py")));
+  body.append(h("pre", { class: "nowrap", html: highlightPython(code) }));
+}
+
+async function tabPrompt({ run, gen, body }) {
+  const label = gen.artifacts.includes("meta_prompt") ? "meta_prompt"
+              : gen.artifacts.includes("feedback_prompt") ? "feedback_prompt" : null;
+  if (!label) { body.append(h("div", { class:"muted" }, "No prompt file.")); return; }
+  body.append(h("div", { class: "spinner" }, "Loading…"));
+  const text = await api(`/api/runs/${run.name}/gens/${gen.name}/artifact/${label}`);
+  body.innerHTML = "";
+  body.append(h("div", { class:"toolbar" }, h("span", { class:"muted" }, label === "meta_prompt" ? "meta_agent_prompt.txt" : "feedback_agent_prompt.txt")));
+  body.append(h("div", { class: "md", html: md(text) }));
+}
+
+async function tabImprovement({ run, gen, body }) {
+  if (!gen.artifacts.includes("improvement")) { body.append(h("div", { class:"muted" }, "No improvement.md (typically gen ≥ 2).")); return; }
+  body.append(h("div", { class: "spinner" }, "Loading…"));
+  const text = await api(`/api/runs/${run.name}/gens/${gen.name}/artifact/improvement`);
+  body.innerHTML = "";
+  body.append(h("div", { class: "md", html: md(text) }));
+}
+
+async function tabLogs({ run, gen, body }) {
+  const which = h("select", {},
+    h("option", { value: "stdout_log" }, "target_agent_stdout.log"),
+    h("option", { value: "eval_log" }, "evaluation.log"));
+  const pre = h("pre", {}, "");
+  const load = async () => {
+    pre.textContent = "Loading…";
+    try { pre.textContent = await api(`/api/runs/${run.name}/gens/${gen.name}/artifact/${which.value}`); }
+    catch { pre.textContent = "(not available)"; }
+  };
+  which.addEventListener("change", load);
+  body.append(h("div", { class: "toolbar" }, which));
+  body.append(pre);
+  load();
+}
+
+async function tabTrajectories({ run, gen, body }) {
+  if (!gen.trajectories?.length) { body.append(h("div", { class:"muted" }, "No per-question trajectories.")); return; }
+  const sel = h("select", {}, gen.trajectories.map(q => h("option", { value: q }, "Question q" + q)));
+  const filter = h("input", { type: "search", placeholder: "filter q… e.g. 42", style:"width:120px" });
+  const host = h("div", {});
+  const load = async () => {
+    host.innerHTML = `<div class="spinner">Loading trajectory…</div>`;
+    try {
+      const turns = await api(`/api/runs/${run.name}/gens/${gen.name}/trajectory/${sel.value}`);
+      host.innerHTML = "";
+      for (const t of turns) {
+        const cls = ["system","user","assistant"].includes(t.role) ? t.role : "tool";
+        host.append(h("div", { class: "turn " + cls },
+          h("div", { class: "role" }, t.role),
+          h("div", { class: "body" }, t.text || "(empty)")));
+      }
+      if (!turns.length) host.append(h("div", { class:"muted" }, "Empty trajectory."));
+    } catch (e) { host.innerHTML = `<div class="empty">Failed: ${esc(e.message)}</div>`; }
+  };
+  filter.addEventListener("input", () => {
+    const v = filter.value.trim();
+    for (const opt of sel.options) opt.hidden = v && !opt.value.includes(v);
+    const first = [...sel.options].find(o => !o.hidden);
+    if (first) { sel.value = first.value; load(); }
+  });
+  sel.addEventListener("change", load);
+  body.append(h("div", { class: "toolbar" },
+    h("span", { class:"muted" }, `${gen.trajectories.length} trajectories`), sel, filter,
+    gen.has_openhands ? h("span", { class:"badge" }, "openhands available") : null));
+  body.append(host);
+  load();
+}
+
+boot();
+</script>
+</body>
+</html>

--- a/tests/test_cli_interface.py
+++ b/tests/test_cli_interface.py
@@ -1,40 +1,47 @@
-"""Verify CLI interface is unchanged after refactoring."""
+"""Verify CLI interface: ``run`` / ``web`` sub-commands and backward-compatible default."""
 
 import subprocess
 import sys
 
 
-def test_help_exits_zero():
-    """sia --help should exit with code 0."""
-    result = subprocess.run(
-        [sys.executable, "-m", "sia", "--help"],
-        capture_output=True,
-        text=True,
-    )
+def _sia(*args):
+    return subprocess.run([sys.executable, "-m", "sia", *args], capture_output=True, text=True)
+
+
+def test_top_level_help_lists_subcommands():
+    """sia --help should exit 0 and advertise both sub-commands."""
+    result = _sia("--help")
     assert result.returncode == 0
-    assert "--max_gen" in result.stdout
-    assert "--task" in result.stdout
-    assert "--task_dir" in result.stdout
-    assert "--meta-profile" in result.stdout
-    assert "--target-profile" in result.stdout
-    assert "--sandbox" in result.stdout
+    assert "run" in result.stdout
+    assert "web" in result.stdout
+
+
+def test_run_help_exposes_orchestrator_flags():
+    """sia run --help should show the orchestrator flags."""
+    result = _sia("run", "--help")
+    assert result.returncode == 0
+    for flag in ("--max_gen", "--task", "--task_dir", "--meta-profile", "--target-profile", "--sandbox"):
+        assert flag in result.stdout
+
+
+def test_web_help_exposes_server_flags():
+    """sia web --help should show the server flags."""
+    result = _sia("web", "--help")
+    assert result.returncode == 0
+    for flag in ("--host", "--port", "--runs-dir"):
+        assert flag in result.stdout
 
 
 def test_no_args_exits_nonzero():
-    """sia without required args should exit non-zero."""
-    result = subprocess.run(
-        [sys.executable, "-m", "sia"],
-        capture_output=True,
-        text=True,
-    )
-    assert result.returncode != 0
+    """sia without a task (defaults to `run`, which requires one) exits non-zero."""
+    assert _sia().returncode != 0
+
+
+def test_default_subcommand_is_run():
+    """`sia --task nonexistent` is treated as `sia run --task nonexistent`."""
+    assert _sia("--task", "nonexistent").returncode != 0
 
 
 def test_invalid_task_exits_nonzero():
-    """sia --task nonexistent should exit non-zero."""
-    result = subprocess.run(
-        [sys.executable, "-m", "sia", "--task", "nonexistent"],
-        capture_output=True,
-        text=True,
-    )
+    result = _sia("run", "--task", "nonexistent")
     assert result.returncode != 0

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,133 @@
+"""Tests for the runs-visualizer data layer and HTTP API."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sia.web import runs as rd
+
+
+@pytest.fixture
+def runs_root(tmp_path: Path) -> Path:
+    """A minimal but realistic runs/ tree: one run, two generations."""
+    root = tmp_path / "runs"
+    gen1 = root / "run_7" / "gen_1"
+    gen2 = root / "run_7" / "gen_2"
+    (gen1 / "agent_execution").mkdir(parents=True)
+    gen2.mkdir(parents=True)
+
+    (root / "run_7" / "context.md").write_text(
+        "# Run Context: run_7\n\n"
+        "**Task**: /tasks/gpqa\n"
+        "**Meta Model**: kimi\n"
+        "**Task Model**: haiku\n"
+        "**Backend**: openhands\n"
+        "**Started**: 2026-06-05 13:31:32\n"
+        "**Max Generations**: 3\n\n"
+        "---\n\n## Generation 1\n**Status**: ok\n",
+        encoding="utf-8",
+    )
+
+    (gen1 / "target_agent.py").write_text("print('hello')\n", encoding="utf-8")
+    (gen1 / "meta_agent_prompt.txt").write_text("meta prompt body", encoding="utf-8")
+    (gen1 / "evaluation_results.json").write_text(
+        json.dumps(
+            {
+                "total_questions": 4,
+                "correct": 2,
+                "incorrect": 2,
+                "accuracy": 0.5,
+                "accuracy_percent": 50.0,
+                "details": [
+                    {"question_id": 1, "domain": "Physics", "is_correct": True},
+                    {"question_id": 2, "domain": "Physics", "is_correct": False},
+                    {"question_id": 3, "domain": "Biology", "is_correct": True},
+                    {"question_id": 4, "domain": "Biology", "is_correct": False},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (gen1 / "agent_execution" / "execution_q1.json").write_text(
+        json.dumps(
+            [
+                {"role": "system", "content": [{"type": "text", "text": "You are an expert."}]},
+                {"role": "user", "content": "Question 1?"},
+                {"role": "assistant", "content": [{"type": "text", "text": "Answer: A"}]},
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    (gen2 / "improvement.md").write_text("# Plan\n- do better\n", encoding="utf-8")
+    return root
+
+
+def test_list_runs_summary(runs_root):
+    runs = rd.list_runs(runs_root)
+    assert len(runs) == 1
+    r = runs[0]
+    assert r.name == "run_7"
+    assert r.backend == "openhands"
+    assert r.task_model == "haiku"
+    assert r.max_generations == 3
+    assert r.num_generations == 2
+    assert r.best_accuracy_percent == 50.0
+
+
+def test_get_run_detail_and_domains(runs_root):
+    detail = rd.get_run(runs_root, "run_7")
+    assert detail is not None
+    assert detail.context_md.startswith("# Run Context")
+    gen1 = next(g for g in detail.generations if g.name == "gen_1")
+    assert gen1.eval.accuracy_percent == 50.0
+    assert "target_agent" in gen1.artifacts
+    assert "meta_prompt" in gen1.artifacts
+    assert gen1.trajectories == [1]
+    domains = {d.domain: d for d in gen1.domains}
+    assert domains["Physics"].correct == 1 and domains["Physics"].total == 2
+    assert domains["Biology"].accuracy_percent == 50.0
+
+
+def test_eval_details_and_artifacts(runs_root):
+    details = rd.get_eval_details(runs_root, "run_7", "gen_1")
+    assert details is not None and len(details) == 4
+    assert rd.get_artifact_text(runs_root, "run_7", "gen_1", "target_agent") == "print('hello')\n"
+    assert rd.get_artifact_text(runs_root, "run_7", "gen_2", "improvement").startswith("# Plan")
+
+
+def test_trajectory_normalization(runs_root):
+    turns = rd.get_trajectory(runs_root, "run_7", "gen_1", 1)
+    assert [t["role"] for t in turns] == ["system", "user", "assistant"]
+    assert turns[0]["text"] == "You are an expert."
+    assert turns[1]["text"] == "Question 1?"
+    assert turns[2]["text"] == "Answer: A"
+
+
+def test_missing_lookups_return_none(runs_root):
+    assert rd.get_run(runs_root, "run_999") is None
+    assert rd.get_trajectory(runs_root, "run_7", "gen_1", 999) is None
+    assert rd.get_artifact_text(runs_root, "run_7", "gen_1", "nope") is None
+
+
+@pytest.mark.parametrize("evil", ["..", "../etc", "run_7/../run_7", "foo/bar", ".", "/abs"])
+def test_path_traversal_is_blocked(runs_root, evil):
+    assert rd.get_run(runs_root, evil) is None
+    assert rd._resolve_gen(runs_root, evil, "gen_1") is None
+    assert rd._resolve_gen(runs_root, "run_7", evil) is None
+
+
+def test_api_endpoints(runs_root):
+    fastapi_testclient = pytest.importorskip("fastapi.testclient")
+    from sia.web import create_app
+
+    client = fastapi_testclient.TestClient(create_app(runs_root))
+
+    assert client.get("/api/runs").json()[0]["name"] == "run_7"
+    assert client.get("/api/runs/run_7").json()["backend"] == "openhands"
+    assert len(client.get("/api/runs/run_7/gens/gen_1/eval").json()) == 4
+    assert "hello" in client.get("/api/runs/run_7/gens/gen_1/artifact/target_agent").text
+    assert client.get("/api/runs/run_7/gens/gen_1/trajectory/1").json()[0]["role"] == "system"
+    assert client.get("/api/runs/run_404").status_code == 404
+    assert client.get("/").status_code == 200

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -119,10 +119,11 @@ def test_path_traversal_is_blocked(runs_root, evil):
 
 
 def test_api_endpoints(runs_root):
-    fastapi_testclient = pytest.importorskip("fastapi.testclient")
+    from fastapi.testclient import TestClient
+
     from sia.web import create_app
 
-    client = fastapi_testclient.TestClient(create_app(runs_root))
+    client = TestClient(create_app(runs_root))
 
     assert client.get("/api/runs").json()[0]["name"] == "run_7"
     assert client.get("/api/runs/run_7").json()["backend"] == "openhands"


### PR DESCRIPTION
## Summary

Adds a FastAPI-based dashboard to browse local `runs/` output: trajectories, target-agent code, prompts, improvement plans, logs, and per-generation scores.

Run it with **`sia web`**, or just run `sia run` — a live dashboard auto-starts in a background thread.

<img width="1507" height="840" alt="Screenshot 2026-06-05 at 3 29 32 PM" src="https://github.com/user-attachments/assets/d4f8d902-c4b6-43b7-a842-42396d5fd6c6" />

## What's included

- **`sia/web/runs.py`** — dependency-light data layer over `runs/run_N/gen_M/`. Pure, testable functions returning pydantic models; path-traversal hardened (every lookup confined to the runs root).
- **`sia/web/server.py`** — FastAPI app factory + `serve()` (foreground) and `serve_in_background()` (daemon thread, degrades gracefully if FastAPI isn't installed).
- **`sia/web/static/index.html`** — dependency-free SPA (no CDN, no build step): run list with accuracy badges, accuracy-across-generations SVG chart, per-generation tabs (Overview/domain breakdown, Agent code, Prompt, Improvement, Trajectories, Logs), a trajectory chat viewer, Python syntax highlighting, and markdown-rendered prompts. Diff-based hash routing so tab/gen switches don't re-render the whole page.
- **CLI** — new `sia web` subcommand; `sia run` auto-starts the live dashboard (`--no-web` / `--web-port` / `--web-host`). Backward compatible: `sia --task ...` still works via a default `run` subcommand.
- **pyproject** — `web` optional extra (`fastapi`, `uvicorn`); ships `web/static/*` as package data.

## Usage

```
sia web                # → http://127.0.0.1:8000
sia run --task gpqa    # dashboard auto-starts alongside the run
pip install 'sia-agent[web]'
```

## Tests

- `tests/test_web.py` — data layer, normalization, path-traversal blocking, and live API via `TestClient`.
- `tests/test_cli_interface.py` — updated for the `run`/`web` subcommands and backward-compatible default.

All 118 tests pass; `ruff` clean.

## Notes

Kept the frontend as a single dependency-free HTML file (no React/build toolchain) so the wheel stays self-contained — see PR discussion for the tradeoff and when a framework would be worth it.