### PR TITLE
chore: bump minor version as cli contracts have changed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sia-agent"
-version = "0.3.0"
+version = "0.4.0"
 description = "SIA: Self-Improving AI framework"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
`0.3.0` -> `0.4.0`