### PR TITLE
fix(gpqa): write evaluator output to results.json

### DIFF
--- a/sia/tasks/gpqa/data/public/evaluate.py
+++ b/sia/tasks/gpqa/data/public/evaluate.py
@@ -68,8 +68,7 @@ def find_submission_file(gen_dir: Path) -> Optional[Path]:
 
     Search order:
     1. Check for results/ subdirectory and look for JSON files there
-    2. Look for common patterns in gen_dir itself (results*.json, submission*.json, etc.)
-    3. If only one JSON file exists, use that
+    2. Look for explicit submission patterns in gen_dir itself
     """
     if not gen_dir.is_dir():
         return None
@@ -82,21 +81,13 @@ def find_submission_file(gen_dir: Path) -> Optional[Path]:
             # Return the most recently modified file from results/
             return max(json_files, key=lambda p: p.stat().st_mtime)
 
-    # Try common patterns in gen_dir itself
-    patterns = ["results*.json", "submission*.json", "output*.json"]
+    # Try explicit submission patterns in gen_dir itself.
+    patterns = ["submission*.json", "output*.json"]
     for pattern in patterns:
         matches = list(gen_dir.glob(pattern))
         if matches:
             # Return the most recently modified file
             return max(matches, key=lambda p: p.stat().st_mtime)
-
-    # If no pattern matches, look for any JSON file
-    json_files = list(gen_dir.glob("*.json"))
-    if len(json_files) == 1:
-        return json_files[0]
-    elif len(json_files) > 1:
-        # Return the most recently modified
-        return max(json_files, key=lambda p: p.stat().st_mtime)
 
     return None
 

--- a/sia/tasks/gpqa/data/public/evaluate.py
+++ b/sia/tasks/gpqa/data/public/evaluate.py
@@ -278,7 +278,7 @@ def main():
         "--output",
         type=Path,
         default=None,
-        help="Path to save evaluation results (default: gen-dir/evaluation_results.json)"
+        help="Path to save evaluation results (default: gen-dir/results.json)"
     )
 
     args = parser.parse_args()
@@ -317,9 +317,9 @@ def main():
     if args.output:
         output_path = args.output
     elif args.gen_dir:
-        output_path = args.gen_dir / "evaluation_results.json"
+        output_path = args.gen_dir / "results.json"
     else:
-        output_path = submission_path.parent / "evaluation_results.json"
+        output_path = submission_path.parent / "results.json"
 
     # Save results
     print(f"Saving results to: {output_path}")

--- a/tests/test_gpqa_evaluator.py
+++ b/tests/test_gpqa_evaluator.py
@@ -1,0 +1,36 @@
+"""Tests for the bundled GPQA evaluator contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+GPQA_EVALUATOR = REPO_ROOT / "sia" / "tasks" / "gpqa" / "data" / "public" / "evaluate.py"
+
+
+def _load_gpqa_evaluator():
+    spec = importlib.util.spec_from_file_location("gpqa_evaluate", GPQA_EVALUATOR)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_default_gen_dir_output_is_results_json(monkeypatch, tmp_path):
+    evaluator = _load_gpqa_evaluator()
+    gen_dir = tmp_path / "gen_1"
+    gen_dir.mkdir()
+    submission_path = gen_dir / "submission.json"
+    submission_path.write_text('{"answers": {"1": "A"}}', encoding="utf-8")
+
+    monkeypatch.setattr(evaluator, "load_ground_truth", lambda _path: [{"id": 1, "correct_answer_letter": "A"}])
+    monkeypatch.setattr(evaluator, "find_submission_file", lambda _gen_dir: submission_path)
+    monkeypatch.setattr(sys, "argv", ["evaluate.py", "--gen-dir", str(gen_dir)])
+
+    evaluator.main()
+
+    assert (gen_dir / "results.json").is_file()
+    assert not (gen_dir / "evaluation_results.json").exists()

--- a/tests/test_gpqa_evaluator.py
+++ b/tests/test_gpqa_evaluator.py
@@ -34,3 +34,25 @@ def test_default_gen_dir_output_is_results_json(monkeypatch, tmp_path):
 
     assert (gen_dir / "results.json").is_file()
     assert not (gen_dir / "evaluation_results.json").exists()
+
+
+def test_find_submission_file_ignores_root_results_json(tmp_path):
+    evaluator = _load_gpqa_evaluator()
+    gen_dir = tmp_path / "gen_1"
+    gen_dir.mkdir()
+    results_path = gen_dir / "results.json"
+    results_path.write_text('{"accuracy": 1.0}', encoding="utf-8")
+    submission_path = gen_dir / "submission.json"
+    submission_path.write_text('{"answers": {"1": "A"}}', encoding="utf-8")
+
+    assert evaluator.find_submission_file(gen_dir) == submission_path
+
+
+def test_find_submission_file_does_not_guess_arbitrary_json(tmp_path):
+    evaluator = _load_gpqa_evaluator()
+    gen_dir = tmp_path / "gen_1"
+    gen_dir.mkdir()
+    (gen_dir / "answers.json").write_text('{"1": "A"}', encoding="utf-8")
+    (gen_dir / "results.json").write_text('{"accuracy": 1.0}', encoding="utf-8")
+
+    assert evaluator.find_submission_file(gen_dir) is None


### PR DESCRIPTION
## Summary
- make the bundled GPQA evaluator write `results.json` by default
- keep explicit `--output` overrides unchanged
- add a regression test for the SIA evaluator artifact contract

## Why
`run_evaluation()` treats `gen_*/results.json` as the canonical evaluator artifact. GPQA previously wrote `evaluation_results.json` by default, so evaluation could complete but the orchestrator would still report that `results.json` was missing.

## Test plan
- `python3 -m pytest tests/test_gpqa_evaluator.py -q`
- `python3 -m pytest tests/test_gpqa_evaluator.py tests/test_run_evaluation.py tests/test_run_evaluation_outcomes.py -q`
- `python3 -m ruff check .`
- `python3 -m pytest -q`
