### PR TITLE
fix: gpqa grader writes results.json so the harness picks it up

### DIFF
--- a/sia/tasks/gpqa/data/public/evaluate.py
+++ b/sia/tasks/gpqa/data/public/evaluate.py
@@ -278,7 +278,7 @@ def main():
         "--output",
         type=Path,
         default=None,
-        help="Path to save evaluation results (default: gen-dir/evaluation_results.json)"
+        help="Path to save evaluation results (default: gen-dir/results.json)"
     )
 
     args = parser.parse_args()
@@ -313,13 +313,16 @@ def main():
     print("Evaluating submission...")
     results = evaluate_submission(submission, correct_answers, questions)
 
-    # Determine output path
+    # Determine output path.
+    # Default filename is results.json: the orchestrator reads gen-dir/results.json
+    # (matching the lawbench and longcot-chess graders), so the grader must write
+    # that name for the evaluation to be picked up by the harness.
     if args.output:
         output_path = args.output
     elif args.gen_dir:
-        output_path = args.gen_dir / "evaluation_results.json"
+        output_path = args.gen_dir / "results.json"
     else:
-        output_path = submission_path.parent / "evaluation_results.json"
+        output_path = submission_path.parent / "results.json"
 
     # Save results
     print(f"Saving results to: {output_path}")

--- a/tests/test_gpqa_grader_output.py
+++ b/tests/test_gpqa_grader_output.py
@@ -1,0 +1,68 @@
+"""The gpqa grader must write results.json so the orchestrator picks it up.
+
+The orchestrator (sia/orchestrator.py) invokes each task's evaluate.py with only
+``--gen-dir`` and then reads ``gen-dir/results.json`` (Names.RESULTS_JSON). A grader
+that defaults its output to any other filename produces no results.json, so the run
+is silently scored as a "warning" and never feeds the feedback loop. This locks the
+gpqa grader to that contract, matching the lawbench and longcot-chess graders.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+GPQA_DIR = REPO_ROOT / "sia" / "tasks" / "gpqa"
+EVALUATE_PY = GPQA_DIR / "data" / "public" / "evaluate.py"
+PRIVATE_QUESTIONS = GPQA_DIR / "data" / "private" / "diamond_questions.json"
+
+
+def _wrong_letter(correct_letter: str) -> str:
+    """Return any A-D letter that differs from the correct one."""
+    return next(letter for letter in "ABCD" if letter != correct_letter)
+
+
+@pytest.fixture
+def gpqa_gen_dir(tmp_path: Path) -> SimpleNamespace:
+    """A generation dir holding a submission under results/, as the agent writes it.
+
+    Answers the first three questions (two correct, one wrong) so the test can assert
+    the grader actually scored this submission rather than emitting an empty result.
+    """
+    questions = json.loads(PRIVATE_QUESTIONS.read_text(encoding="utf-8"))
+    sample = questions[:3]
+    details = [
+        {"question_id": sample[0]["id"], "model_answer": sample[0]["correct_answer_letter"]},
+        {"question_id": sample[1]["id"], "model_answer": sample[1]["correct_answer_letter"]},
+        {"question_id": sample[2]["id"], "model_answer": _wrong_letter(sample[2]["correct_answer_letter"])},
+    ]
+
+    results_subdir = tmp_path / "results"
+    results_subdir.mkdir()
+    (results_subdir / "submission.json").write_text(json.dumps({"details": details}), encoding="utf-8")
+
+    return SimpleNamespace(path=tmp_path, expected_correct=2, expected_incorrect=1)
+
+
+def test_gpqa_evaluate_writes_results_json_under_gen_dir(gpqa_gen_dir: SimpleNamespace):
+    gen_dir = gpqa_gen_dir.path
+    result = subprocess.run(
+        [sys.executable, str(EVALUATE_PY), "--gen-dir", str(gen_dir)],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, f"grader failed: {result.stdout}\n{result.stderr}"
+
+    results_json = gen_dir / "results.json"
+    assert results_json.is_file(), "grader did not write the orchestrator-expected results.json"
+    assert not (gen_dir / "evaluation_results.json").exists(), "grader wrote the legacy filename"
+
+    scored = json.loads(results_json.read_text(encoding="utf-8"))
+    assert scored["correct"] == gpqa_gen_dir.expected_correct
+    assert scored["incorrect"] == gpqa_gen_dir.expected_incorrect
+    assert "accuracy" in scored


### PR DESCRIPTION
## Problem

The gpqa task's grader never produces results the harness can read, so gpqa runs are silently scored as a "warning" and the scores never reach the feedback loop.

The orchestrator runs each task's `evaluate.py` with only `--gen-dir` and then reads `gen-dir/results.json`:

- `run_evaluation()` invokes `[python, evaluate.py, "--gen-dir", gen_directory]` (no `--output`).
- It then checks `os.path.exists(gen-dir/results.json)` (`Names.RESULTS_JSON`).

The gpqa grader, however, defaulted its output to `gen-dir/evaluation_results.json`. With no `--output` passed, it wrote the wrong filename, so `results.json` was never created and `run_evaluation()` fell through to:

> ⚠ Evaluation completed but results.json not found

The sibling graders already honor this contract — `lawbench` writes `results.json` (its code even comments "required by orchestrator") and `longcot-chess` defaults to `results.json`. gpqa was the lone outlier.

## Fix

Default the gpqa grader's output filename to `results.json` (the explicit `--output` flag still overrides). This is a one-file, three-line change in `sia/tasks/gpqa/data/public/evaluate.py`, plus a brief comment recording the contract so it does not drift again.

## Why it's safe

The submission-discovery path is unaffected. The gpqa reference agent writes its submission into the `results/` subdirectory, and `find_submission_file()` checks `results/` before the `gen-dir` root — so the grader's own `results.json` at the gen-dir root is never mistaken for a submission. This is exactly how `longcot-chess` already behaves.

## Tests

Added `tests/test_gpqa_grader_output.py`, which runs the real grader the way the orchestrator does (`--gen-dir` only) against the private ground truth and a synthetic submission, then asserts `results.json` (not `evaluation_results.json`) is written and scored correctly. Verified it fails against the previous grader and passes with this change. The existing eval/task/context/orchestrator suites continue to pass.
