### PR TITLE
docs: add star history chart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![PyPI version](https://img.shields.io/pypi/v/sia-agent.svg)](https://pypi.org/project/sia-agent/)
 
+<p align="center">
+  <a href="https://star-history.com/#hexo-ai/sia&Date">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=hexo-ai/sia&type=Date&theme=dark" />
+      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=hexo-ai/sia&type=Date" />
+      <img alt="SIA Star History Chart" src="https://api.star-history.com/svg?repos=hexo-ai/sia&type=Date" width="600" />
+    </picture>
+  </a>
+</p>
+
 Official implementation of [**SIA: Self Improving AI with Harness & Weight Updates**](https://arxiv.org/abs/2605.27276) (Hebbar et al., 2026) — a self-improving loop where a language-model agent updates both the harness and the weights of a task-specific agent. The paper reports a 56.6% gain on LawBench, 91.9% runtime reduction on GPU kernels, and 502% improvement on single-cell RNA denoising over baseline.
 
 SIA is a Self Improving AI framework to autonomously improve the performance of any AI system (Model / Agent) on a benchmark task.


### PR DESCRIPTION
## What

Adds a [star-history.com](https://star-history.com) chart to the README, placed directly below the badge block (arXiv / License / Python / PyPI).

## Why this format

Surveyed how major repos handle this: of every large repo that includes a star graph (immich, lobe-chat, dify, LibreChat, anything-llm), **100% use star-history.com** — there is no alternative service for README embeds (GitHub markdown blocks iframes).

Used the `<picture>` element with **dark/light theme variants** — the most polished form, matching [immich](https://github.com/immich-app/immich) and [lobe-chat](https://github.com/lobehub/lobe-chat). It adapts to the viewer's GitHub color scheme instead of rendering a fixed light chart on dark backgrounds.

## Preview

```html
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=hexo-ai/sia&type=Date&theme=dark" />
  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=hexo-ai/sia&type=Date" />
  <img alt="SIA Star History Chart" src="https://api.star-history.com/svg?repos=hexo-ai/sia&type=Date" width="600" />
</picture>
```

Both theme endpoints verified returning valid SVGs with live `hexo-ai/sia` star data.