### PR TITLE
 Fix: stale references to renamed/moved code

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Artifacts land in `runs/run_{run_id}/gen_{n}/`:
 - `improvement.md` — diff rationale (gen 2+)
 
 While a run is in progress a **live dashboard** auto-starts at
-`http://127.0.0.1:8000` (requires the `web` extra; disable with `--no-web`).
+`http://127.0.0.1:8000` (disable with `--no-web`).
 
 ### Common flags (`sia run`)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,7 +35,7 @@ When `--sandbox docker` is used:
 
 Requirements: Docker must be installed and the user must have permission to run containers.
 
-### bypassPermissions in util.py
+### bypassPermissions in sia/agent_impls/claude.py
 
 The Claude Code SDK agent runner uses `permission_mode="bypassPermissions"`. This is required for automated agent execution -- without it, the agent would pause and wait for human approval on every file operation. This is safe when:
 - Operating in a controlled workspace

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,7 +32,8 @@ sia/
 ├── sia/
 │   ├── orchestrator.py             # Main orchestration logic
 │   ├── context_manager.py          # Run/context tracking
-│   ├── util.py                     # Agent runner utilities
+│   ├── prompts.py                  # Meta and feedback prompt builders
+│   ├── agent_impls/                # Agent runner backends (claude / openhands / pydantic-ai)
 │   ├── prepare_mlebench_dataset.py # MLE-Bench dataset preparation
 │   └── tasks/                      # Bundled with the wheel
 │       ├── _shared/
@@ -58,7 +59,7 @@ sia/
 
 ## Customizing prompts
 
-The two prompts that drive self-improvement live in [`sia/orchestrator.py`](../sia/orchestrator.py):
+The two prompts that drive self-improvement live in [`sia/prompts.py`](../sia/prompts.py):
 
-- `META_AGENT_PROMPT` — controls how the initial Target Agent is created
-- `FEEDBACK_AGENT_PROMPT` — controls how improvements are suggested
+- `build_meta_prompt(...)` — controls how the initial Target Agent is created
+- `build_feedback_prompt(...)` — controls how improvements are suggested

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -210,7 +210,7 @@ sia web --runs-dir ./runs --port 8080    # custom directory / port
 
 The same dashboard auto-starts in a background thread during `sia run` so you can
 watch generations land live; pass `--no-web` to disable it, or `--web-port` /
-`--web-host` to change where it binds. If the `web` extra isn't installed, the
+`--web-host` to change where it binds. If FastAPI/uvicorn are missing, the
 run logs a warning and continues without the dashboard.
 
 ## Weights Mode (RL-based tuning)
@@ -278,8 +278,8 @@ sia run --task gpqa --max_gen 5 --run_id 1 --focus weights --training_sandbox sa
 
 ## Environment-variable defaults
 
-`SIA_META_PROFILE` / `SIA_TARGET_PROFILE` set the default profile names (overridden by the CLI
-flags). `SIA_MAX_GENERATIONS`, `SIA_MAX_TURNS`, and `SIA_SANDBOX_MODE` are also honored.
+`SIA_META_AGENT_PROFILE` / `SIA_TARGET_AGENT_PROFILE` set the default profile names (overridden by
+the CLI flags). `SIA_MAX_GENERATIONS`, `SIA_MAX_TURNS`, and `SIA_SANDBOX_MODE` are also honored.
 
 ## Notes
 

--- a/sia/web/server.py
+++ b/sia/web/server.py
@@ -25,7 +25,7 @@ def create_app(runs_dir: str | Path):
         from fastapi.responses import FileResponse, PlainTextResponse
     except ModuleNotFoundError as exc:  # pragma: no cover - import guard
         raise RuntimeError(
-            "The web visualizer needs FastAPI + uvicorn. Install with:\n    pip install 'sia-agent[web]'"
+            "The web visualizer needs FastAPI + uvicorn. Install with:\n    pip install fastapi uvicorn"
         ) from exc
 
     runs_root = Path(runs_dir).resolve()


### PR DESCRIPTION
After the modular refactor (#18) and the web visualizer (#19) several references in the docs and one user-facing error message went stale:

- docs/configuration.md: env var defaults referenced SIA_META_PROFILE / SIA_TARGET_PROFILE; the real names are SIA_META_AGENT_PROFILE / SIA_TARGET_AGENT_PROFILE (see sia/config.py).
- SECURITY.md: bypassPermissions section pointed at util.py, which is now a backward-compat shim; the option is in sia/agent_impls/claude.py.
- sia/web/server.py and the README/configuration docs suggested installing a 'sia-agent[web]' extra that does not exist in pyproject.toml - fastapi and uvicorn are already in the base dependencies, so the dashboard is always available.
- docs/architecture.md: directory tree still listed util.py as "Agent runner utilities" and pointed at META_AGENT_PROMPT / FEEDBACK_AGENT_PROMPT constants in orchestrator.py; the prompts now live in sia/prompts.py as build_meta_prompt / build_feedback_prompt, and the agent runners are under sia/agent_impls/.

No behavior change. ruff check and ruff format --check both pass.