### PR TITLE
Docs/add code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,93 @@
+# Code of Conduct
+
+## Our Commitment
+
+SIA is an open source project for people who want to build, use, test, document, and improve self-improving AI systems. We want the project community to be professional, constructive, and welcoming to contributors with different backgrounds, experience levels, and areas of expertise.
+
+Everyone participating in SIA spaces is expected to help maintain an environment where people can collaborate respectfully and focus on the work.
+
+## Scope
+
+This Code of Conduct applies to project spaces, including:
+
+* GitHub issues, pull requests, discussions, and reviews
+* Project documentation and examples
+* Official project chat, forum, or community spaces if created
+* Public spaces where someone is clearly representing the SIA project
+
+It does not limit maintainers from moderating off-topic, disruptive, unsafe, or abusive behavior in project spaces.
+
+## Expected Behavior
+
+Project participants are expected to:
+
+* Be respectful, professional, and constructive.
+* Assume good intent when reasonable, and ask clarifying questions before escalating disagreements.
+* Focus criticism on ideas, code, documentation, designs, benchmarks, or processes rather than on people.
+* Accept constructive feedback gracefully.
+* Help newcomers find the right documentation, issue, or discussion when possible.
+* Respect project maintainers' time by keeping issues and pull requests focused and actionable.
+* Avoid sharing private information, credentials, proprietary data, or sensitive task data in public project spaces.
+
+## Unacceptable Behavior
+
+The following behavior is not acceptable in project spaces:
+
+* Harassment, threats, intimidation, or sustained disruption.
+* Personal attacks, insults, or hostile comments directed at another participant.
+* Sexualized language or imagery, or unwelcome sexual attention.
+* Publishing another person's private information without explicit permission.
+* Deliberately derailing issues, pull requests, or discussions.
+* Repeatedly ignoring maintainer requests to stop disruptive behavior.
+* Encouraging or assisting others in violating this Code of Conduct.
+* Using project spaces to promote spam, scams, malware, credential theft, or unsafe handling of secrets.
+
+## Reporting
+
+If you experience or observe behavior that may violate this Code of Conduct, please report it privately to the project maintainers.
+
+**Maintainer action required before merging:** replace this paragraph with Hexo's preferred private reporting contact, such as a monitored email address or private reporting process. Do not ask people to report conduct issues in public GitHub issues.
+
+Reports should include as much of the following as you are comfortable providing:
+
+* What happened
+* Where it happened
+* When it happened
+* Who was involved
+* Any relevant links, screenshots, or context
+
+Maintainers should handle reports with discretion and limit information sharing to people who need it to review and respond.
+
+## Enforcement
+
+Maintainers are responsible for clarifying and enforcing this Code of Conduct in project spaces. Enforcement should be fair, proportionate, and focused on protecting the health of the project community.
+
+Depending on the circumstances, maintainers may take actions including:
+
+1. A private clarification or reminder
+2. A warning
+3. Editing, hiding, or removing comments or content
+4. Temporarily limiting participation
+5. Closing or locking issues, pull requests, or discussions
+6. Banning a participant from project spaces
+
+Maintainers who are directly involved in a reported incident should recuse themselves from handling that report when possible.
+
+## Good-Faith Participation
+
+Disagreement is expected in technical projects. This Code of Conduct is not intended to prevent direct technical feedback, disagreement, or criticism. It is intended to keep collaboration productive and respectful.
+
+Examples of acceptable participation include:
+
+* Challenging a design decision with evidence
+* Pointing out bugs, security concerns, or benchmark limitations
+* Asking for clearer documentation or reproducible examples
+* Declining a proposed change with a clear explanation
+* Requesting changes to code, tests, documentation, or project process
+
+The goal is not to avoid disagreement. The goal is to handle disagreement in a way that helps the project improve.
+
+## Attribution
+
+This Code of Conduct is informed by widely used open source community standards, including the Contributor Covenant, the GitHub Community Code of Conduct, and code of conduct practices used by open source foundations.
+::: 


### PR DESCRIPTION
- Added a project-specific code of conduct for SIA.
- Defined expected professional and constructive participation.
- Listed unacceptable behavior for project spaces.
- Added reporting guidance for conduct concerns.
- Added maintainer enforcement guidance.
- Included good-faith participation language to clarify that direct technical disagreement and critique are welcome when handled constructively.
