### PR TITLE
feat(providers): add Eden AI as an OpenAI-compatible provider

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,7 +59,12 @@ Configuration is **declarative JSON** you can extend without touching code.
 }
 ```
 
-Bundled providers: `anthropic`, `gemini`, `openai`, `together`, `nebius`.
+Bundled providers: `anthropic`, `gemini`, `openai`, `together`, `nebius`, `edenai`.
+
+> `edenai` ([Eden AI](https://www.edenai.co/)) is an OpenAI-compatible gateway to 100+ models
+> (Mistral, OpenAI, Anthropic, Google, and more) through a single EU-based endpoint and one
+> `EDENAI_API_KEY`. Because `client_kind` is `openai`, the generated target agent talks to it
+> with the OpenAI SDK at Eden's `base_url` — no code change.
 
 ### Profiles — one per agent role
 
@@ -185,6 +190,7 @@ export GEMINI_API_KEY="..."      # gemini provider  (or GOOGLE_API_KEY via openh
 export OPENAI_API_KEY="..."      # openai provider
 export TOGETHER_API_KEY="..."    # together provider
 export NEBIUS_API_KEY="..."      # nebius provider
+export EDENAI_API_KEY="..."      # edenai provider (OpenAI-compatible gateway)
 ```
 
 ## Comparing multiple LLMs on the same task

--- a/sia/defaults/providers/edenai.json
+++ b/sia/defaults/providers/edenai.json
@@ -1,0 +1,7 @@
+{
+  "provider_id": "edenai",
+  "name": "Eden AI",
+  "client_kind": "openai",
+  "base_url": "https://api.edenai.run/v3",
+  "api_key_env": "EDENAI_API_KEY"
+}

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -8,7 +8,7 @@ from sia.providers import Provider, available_providers, load_provider
 
 
 def test_bundled_providers_present():
-    assert set(available_providers()) >= {"anthropic", "gemini", "openai", "together", "nebius"}
+    assert set(available_providers()) >= {"anthropic", "gemini", "openai", "together", "nebius", "edenai"}
 
 
 def test_load_anthropic_provider():
@@ -25,6 +25,15 @@ def test_load_nebius_provider():
     assert p.client_kind == "openai"
     assert p.base_url == "https://api.tokenfactory.us-central1.nebius.com/v1/"
     assert p.api_key_env == "NEBIUS_API_KEY"
+
+
+def test_load_edenai_provider():
+    p = load_provider("edenai")
+    assert isinstance(p, Provider)
+    assert p.provider_id == "edenai"
+    assert p.client_kind == "openai"
+    assert p.base_url == "https://api.edenai.run/v3"
+    assert p.api_key_env == "EDENAI_API_KEY"
 
 
 def test_unknown_provider_name_raises():


### PR DESCRIPTION
## Summary

Adds **Eden AI** as an OpenAI-compatible provider. Eden AI is an EU-based unified API to 100+ models (Mistral, OpenAI, Anthropic, Google, …) behind a single OpenAI-compatible endpoint and one key. Per `sia/providers.py` ("Adding a provider is dropping a JSON file — no code change"), this is a JSON drop-in.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] New or updated task
- [ ] Evaluation change
- [x] Provider/model configuration
- [ ] Security-sensitive change
- [ ] Refactor / maintenance
- [ ] Other

## Related issue

N/A (small, clearly-scoped provider addition)

## What changed

- add `sia/defaults/providers/edenai.json` (`client_kind = openai`, `base_url = https://api.edenai.run/v3`, `api_key_env = EDENAI_API_KEY`)
- cover it in `tests/test_providers.py` (bundled set + `test_load_edenai_provider`)
- document it in `docs/configuration.md` (bundled providers list + `EDENAI_API_KEY` in the API keys section)

## How I tested this

```bash
pip install -e ".[dev]"
python -m pytest tests/ -v      # 130 passed, 1 skipped
ruff check sia/ tests/          # passed
ruff format --check sia/ tests/ # passed
```

Also verified end-to-end against the live Eden AI API: SIA loads the `edenai` provider and an OpenAI-SDK client at `base_url` returns valid completions for `mistral/mistral-small-latest` and `openai/gpt-4o-mini`.

## Security and privacy checklist

- [x] This change does not log API keys, secrets, private task data, or generated credentials.
- [x] This change does not weaken sandboxing, subprocess isolation, or task data boundaries.

The provider file stores only the **name** of the environment variable (`EDENAI_API_KEY`), never a key value; the key is read from the environment at runtime, consistent with the other bundled providers.
