### PR TITLE
fix: teach the meta agent the OpenAI response shape

### DIFF
--- a/sia/prompts.py
+++ b/sia/prompts.py
@@ -741,6 +741,26 @@ set any cost field to 0 (token counts from the API response are still fine to re
 Pass a finite timeout to every request if the client method supports it, and cap
 retries at 2 so a stalled provider response cannot hang the whole evaluation.
 
+CRITICAL — the response shape is NOT the same. This is the most common way this
+refactor breaks. An OpenAI-style response has NO content blocks: `message.content` is a
+plain string (or None), and tool calls live in a separate `message.tool_calls` list.
+Iterating `message.content` and reading `block.type` / `block.text` / `block.input` is
+Anthropic-only and raises `AttributeError: 'str' object has no attribute 'type'`.
+Port every response-handling branch, not just the client construction:
+
+    msg = response.choices[0].message
+    if msg.content:                          # plain string, not a list of blocks
+        print(msg.content)
+    for call in (msg.tool_calls or []):      # separate list, absent when no tools used
+        name = call.function.name
+        args = json.loads(call.function.arguments)   # a JSON *string*, must be parsed
+        tool_id = call.id
+
+Append the assistant turn as the message object itself, then one message per tool
+result — `{{"role": "tool", "tool_call_id": tool_id, "content": result_str}}` — rather
+than Anthropic's single user message carrying `tool_result` blocks. Stop when
+`response.choices[0].finish_reason != "tool_calls"`.
+
 """
 
 

--- a/tests/golden/meta_prompt_openai.txt
+++ b/tests/golden/meta_prompt_openai.txt
@@ -21,6 +21,26 @@ set any cost field to 0 (token counts from the API response are still fine to re
 Pass a finite timeout to every request if the client method supports it, and cap
 retries at 2 so a stalled provider response cannot hang the whole evaluation.
 
+CRITICAL — the response shape is NOT the same. This is the most common way this
+refactor breaks. An OpenAI-style response has NO content blocks: `message.content` is a
+plain string (or None), and tool calls live in a separate `message.tool_calls` list.
+Iterating `message.content` and reading `block.type` / `block.text` / `block.input` is
+Anthropic-only and raises `AttributeError: 'str' object has no attribute 'type'`.
+Port every response-handling branch, not just the client construction:
+
+    msg = response.choices[0].message
+    if msg.content:                          # plain string, not a list of blocks
+        print(msg.content)
+    for call in (msg.tool_calls or []):      # separate list, absent when no tools used
+        name = call.function.name
+        args = json.loads(call.function.arguments)   # a JSON *string*, must be parsed
+        tool_id = call.id
+
+Append the assistant turn as the message object itself, then one message per tool
+result — `{"role": "tool", "tool_call_id": tool_id, "content": result_str}` — rather
+than Anthropic's single user message carrying `tool_result` blocks. Stop when
+`response.choices[0].finish_reason != "tool_calls"`.
+
 You are a meta-agent. Your task is to create a target agent which can execute a task. Go ahead and create a target_agent.py for the target agent, which in turn can solve the given task.
 
 Here is the FULL TASK SPECIFICATION that your target_agent.py will need to solve:


### PR DESCRIPTION
## Summary

`build_target_client_setup` tells the meta agent how to construct an OpenAI client and send
OpenAI-style messages, but says nothing about the **response** shape. The meta agent therefore
refactors the client while leaving the reference agent's Anthropic content-block loop intact,
and the generated `target_agent.py` dies on its first model response:

```
File "runs/run_999/gen_1/target_agent.py", line 254, in run_agent
    if block.type == "text" and block.text.strip():
AttributeError: 'str' object has no attribute 'type'
```

An OpenAI-style response has no content blocks: `message.content` is a plain string and tool
calls live in a separate `message.tool_calls` list, with `function.arguments` as a JSON string
that must be parsed.

This affects **every** provider with `client_kind: "openai"` — `nebius`, `together`, `tinker`,
`openrouter` — since they all receive this prompt block. It is not specific to any one provider.

## Type of change

Select all that apply:

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] New or updated task
- [ ] Evaluation change
- [ ] Provider/model configuration
- [ ] Security-sensitive change
- [ ] Refactor / maintenance
- [ ] Other

## Related issue

Closes #

## What changed

- `sia/prompts.py` — appends a response-shape section to `build_target_client_setup`, stating that `message.content` is a plain string, that tool calls live in `message.tool_calls`, that `call.function.arguments` is a JSON string needing `json.loads`, that tool results are separate `{"role": "tool", "tool_call_id": ...}` messages rather than Anthropic `tool_result` blocks, and that the loop ends when `finish_reason != "tool_calls"`. Braces are doubled for `.format()`.
- `tests/golden/meta_prompt_openai.txt` — regenerated.

Both `build_meta_agent_prompt` and `build_feedback_prompt` prepend `build_target_client_setup`,
so this single edit covers agent creation and every subsequent improvement generation.

The golden diff is **additions only**, and `tests/golden/meta_prompt.txt` (the anthropic path)
is unchanged — non-openai providers still get byte-identical prompt text, which
`test_meta_prompt_anthropic_provider_is_byte_identical` asserts.

## How I tested this

```bash
# the golden test genuinely guards this — it fails before regenerating
python -m pytest tests/test_prompts_snapshot.py -q
#   FAILED test_meta_prompt_openai_provider_golden - Golden mismatch

UPDATE_GOLDEN=1 python -m pytest tests/
git diff --stat tests/golden/          # 1 file, 20 insertions, 0 deletions

python -m pytest tests/ -v             # 133 passed
ruff check sia/ tests/                 # All checks passed!
ruff format --check sia/ tests/        # 51 files already formatted
ty check sia/                          # All checks passed!
```

End-to-end: a `sia run --max_gen 1` on `spaceship-titanic` through an OpenAI-compatible provider
reproduced the crash above. After this change, a regenerated `target_agent.py` used
`msg.content` / `msg.tool_calls` / `json.loads(tc.function.arguments)` / `role: "tool"` correctly
and the `AttributeError` was gone.

**Caveat, stated plainly:** that confirmation run used `openai/gpt-oss-120b` rather than a Claude
model, because the test key's credit cap could not fund a second run with the more expensive
model. It cleared the `AttributeError` but then failed for an unrelated reason — gpt-oss wrote an
agent that reads its task from stdin, which the orchestrator does not supply. So this fix is
confirmed to remove the response-parsing failure, but **no gen-0 has yet been observed producing
a fully working target agent end to end.** Worth a funded run on a stronger model before relying
on it.

## Security and privacy checklist

- [x] This change does not log API keys, secrets, private task data, or generated credentials.
- [x] This change does not weaken sandboxing, subprocess isolation, or task data boundaries.
- [ ] Security-sensitive behavior is explained in the PR description.
- [x] Not applicable.

## Documentation checklist

- [ ] I updated README.md, CONTRIBUTING.md, SECURITY.md, or docs files as needed.
- [ ] I added or updated examples where helpful.
- [x] Documentation is not needed for this change.

## Contributor checklist

- [x] I ran the relevant tests.
- [x] I ran linting and formatting checks.
- [x] I kept the PR focused on one logical change.
- [x] I reviewed my own diff before requesting review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HPkffXZbzVPFLiaEy2PRfB
