### PR TITLE
fix: route gateways via their own litellm provider so prompt caching works

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,9 +55,16 @@ Configuration is **declarative JSON** you can extend without touching code.
   "name": "Nebius Token Factory",                            // human-readable display name
   "client_kind": "openai",                                   // anthropic | openai | google
   "base_url": "https://api.tokenfactory.us-central1.nebius.com/v1/",
-  "api_key_env": "NEBIUS_API_KEY"
+  "api_key_env": "NEBIUS_API_KEY",
+  "litellm_prefix": "openrouter"                             // optional; see below
 }
 ```
+
+`litellm_prefix` (optional, `openai` by default) names the litellm provider the `openhands` agent
+impl routes through. Most OpenAI-compatible endpoints want the default. Set it when litellm models
+the gateway as a first-class provider — OpenRouter does — because the generic OpenAI transform
+**strips `cache_control` from every message**, silently disabling prompt caching, and cannot report
+usage or cost. Naming the provider fixes all three.
 
 Bundled providers: `anthropic`, `gemini`, `openai`, `together`, `nebius`, `openrouter`.
 
@@ -72,9 +79,17 @@ A **meta-agent profile** bundles `(agent_impl, model, provider)`:
   "name": "Kimi K2.6 on Nebius",    // human-readable display name
   "agent_impl": "openhands",        // claude | openhands | pydantic-ai
   "model": "moonshotai/Kimi-K2.6",
-  "provider_id": "nebius"           // references a provider by its provider_id
+  "provider_id": "nebius",          // references a provider by its provider_id
+  "model_canonical_name": null      // optional; see below
 }
 ```
+
+`model_canonical_name` (optional) is the vendor's own model id, used **only** for SDK capability
+lookups — prompt caching, context window, cost — while `model` stays the routing id the gateway
+expects. Set it when the two differ: OpenRouter serves Anthropic's `claude-haiku-4-5` as
+`anthropic/claude-haiku-4.5`, and capability tables key on the hyphenated form, so without it
+caching stays off and the context window is undetected. **Change it whenever you change `model`** —
+a stale value applies the wrong model's capabilities, token limits and pricing.
 
 A **target-agent profile** bundles `(model, provider, agent_reference)` — no agent impl, because
 SIA never runs the target as an engine; it generates and improves the code:
@@ -173,12 +188,21 @@ sia run --task gpqa \
 Both bundled OpenRouter profiles use `anthropic/claude-haiku-4.5`. To swap models, copy them into
 `./profiles/` and change `model` to any [OpenRouter model id](https://openrouter.ai/models) —
 the id must keep its vendor namespace (`openai/gpt-oss-120b`, `google/gemini-3-flash-preview`,
-`qwen/qwen3-235b-a22b-2507`), since that is how OpenRouter routes.
+`qwen/qwen3-235b-a22b-2507`), since that is how OpenRouter routes. When you change `model` on the
+**meta** profile, update `model_canonical_name` to match the vendor's own id for that model, or
+delete it — leaving the old value applies the wrong model's capabilities and pricing.
 
 The meta agent cannot use the `claude` agent impl here (see below): OpenRouter is an
-OpenAI-compatible provider, so `openrouter-meta` uses `openhands`. LiteLLM prints a
-`Cost calculation failed: This model isn't mapped yet` warning and reports `$0.00` per turn —
-harmless, and consistent with every other non-native provider. Track real spend on the
+OpenAI-compatible provider, so `openrouter-meta` uses `openhands`.
+
+**Prompt caching is model-gated, not provider-gated.** OpenRouter only accepts Anthropic-style
+cache breakpoints for a subset of models — ids containing `claude`, `gemini`, `glm`, `minimax` or
+`z-ai`. Swapping the meta model to, say, `openai/gpt-oss-120b` routes and runs fine but caches
+nothing, so a long meta-agent loop re-sends its whole prefix every turn.
+
+Cost reporting reflects the **native vendor's** published prices, looked up via
+`model_canonical_name` — not OpenRouter's, which adds a fee and varies by route. Treat per-turn
+figures as an estimate and track real spend on the
 [OpenRouter activity page](https://openrouter.ai/activity).
 
 ### Pointing the meta/feedback agent at another provider

--- a/sia/agent_impls/base.py
+++ b/sia/agent_impls/base.py
@@ -11,7 +11,7 @@ what's installed.
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from sia.logging_setup import get_logger
 
@@ -53,6 +53,7 @@ async def run_agent(
     agent_working_directory: str,
     agent_impl: str = "claude",
     provider: Provider | None = None,
+    model_canonical_name: str | None = None,
 ) -> None:
     """Dispatch to the named agent impl.
 
@@ -63,6 +64,13 @@ async def run_agent(
         agent_working_directory: Working directory for the agent.
         agent_impl: Which registered impl to use (e.g. "claude", "openhands", "pydantic-ai").
         provider: Optional endpoint/credentials for the model (api_key_env, base_url).
+        model_canonical_name: Optional canonical model id for SDK capability lookups. Only
+            forwarded when set, so runners registered against the older signature -- including
+            third-party impls -- keep working; when it is set and the runner cannot accept it,
+            the resulting TypeError is loud rather than a silently ignored capability.
     """
     logger.info(f"Using {agent_impl} agent impl")
-    await get_agent_impl(agent_impl)(model_name, max_turns, prompt, agent_working_directory, provider=provider)
+    kwargs: dict[str, Any] = {"provider": provider}
+    if model_canonical_name is not None:
+        kwargs["model_canonical_name"] = model_canonical_name
+    await get_agent_impl(agent_impl)(model_name, max_turns, prompt, agent_working_directory, **kwargs)

--- a/sia/agent_impls/openhands.py
+++ b/sia/agent_impls/openhands.py
@@ -17,19 +17,29 @@ def _resolve_model(model_name, provider=None):
 
     litellm derives the provider from the model string's prefix. For an
     OpenAI-compatible endpoint (a provider with ``client_kind == "openai"`` and a
-    ``base_url``), the model must carry an explicit ``openai/`` prefix so litellm
-    routes to that ``base_url`` instead of trying to parse the model's own namespace
-    (e.g. ``moonshotai/Kimi-K2.6``) as a provider. Already-prefixed and native
-    (anthropic) specs pass through unchanged.
+    ``base_url``), the model must carry an explicit routing prefix so litellm routes to
+    that ``base_url`` instead of trying to parse the model's own namespace (e.g.
+    ``moonshotai/Kimi-K2.6``) as a provider. Already-prefixed and native (anthropic)
+    specs pass through unchanged.
+
+    The prefix comes from the provider's ``litellm_prefix`` and defaults to ``openai``,
+    the generic OpenAI-compatible route. A gateway that litellm models as a first-class
+    provider should name it (``openrouter``) so litellm applies that provider's own
+    request transform: the generic OpenAI transform strips ``cache_control`` from every
+    message, which silently disables prompt caching.
     """
     if provider is None or not isinstance(model_name, str):
         return model_name
-    if provider.client_kind == "openai" and provider.base_url and not model_name.startswith("openai/"):
-        return f"openai/{model_name}"
+    if provider.client_kind == "openai" and provider.base_url:
+        prefix = provider.litellm_prefix or "openai"
+        if not model_name.startswith(f"{prefix}/"):
+            return f"{prefix}/{model_name}"
     return model_name
 
 
-async def run_agent_openhands(model_name, max_turns, prompt, agent_working_directory, provider=None):
+async def run_agent_openhands(
+    model_name, max_turns, prompt, agent_working_directory, provider=None, model_canonical_name=None
+):
     """Run agent using OpenHands SDK"""
     try:
         from openhands.sdk import LLM, Agent, Conversation, Tool
@@ -58,11 +68,26 @@ async def run_agent_openhands(model_name, max_turns, prompt, agent_working_direc
 
         # Create LLM instance. litellm needs an explicit provider prefix to route to a
         # custom OpenAI-compatible base_url (see _resolve_model).
+        #
+        # reasoning_effort is pinned to None deliberately. The SDK defaults it to "high",
+        # and litellm only forwards it for providers it reports as reasoning-capable -- so
+        # merely naming a gateway's litellm provider would silently switch the meta agent
+        # to extended thinking. Opting into that is a separate, measurable decision.
         llm = LLM(
             model=_resolve_model(model_name, provider),
+            model_canonical_name=model_canonical_name,
             api_key=api_key,
             base_url=base_url,
+            reasoning_effort=None,
         )
+        # The LLM model ignores unknown fields, so an SDK predating model_canonical_name
+        # would drop it and leave capability lookups (prompt caching, context window, cost)
+        # silently degraded rather than failing.
+        if model_canonical_name and getattr(llm, "model_canonical_name", None) != model_canonical_name:
+            logger.warning(
+                f"The installed OpenHands SDK ignored model_canonical_name={model_canonical_name!r}; "
+                "prompt caching and context-window detection will be degraded. Upgrade openhands-ai."
+            )
 
         # Create agent with available tools
         agent = Agent(

--- a/sia/defaults/profiles/openrouter-meta.json
+++ b/sia/defaults/profiles/openrouter-meta.json
@@ -3,5 +3,6 @@
   "name": "OpenRouter meta agent (Claude Haiku 4.5, OpenHands)",
   "agent_impl": "openhands",
   "model": "anthropic/claude-haiku-4.5",
+  "model_canonical_name": "claude-haiku-4-5",
   "provider_id": "openrouter"
 }

--- a/sia/defaults/providers/openrouter.json
+++ b/sia/defaults/providers/openrouter.json
@@ -3,5 +3,6 @@
   "name": "OpenRouter",
   "client_kind": "openai",
   "base_url": "https://openrouter.ai/api/v1",
-  "api_key_env": "OPENROUTER_API_KEY"
+  "api_key_env": "OPENROUTER_API_KEY",
+  "litellm_prefix": "openrouter"
 }

--- a/sia/orchestrator.py
+++ b/sia/orchestrator.py
@@ -625,6 +625,7 @@ def _run_feedback_agent(
             agent_working_directory=next_gen_dir,
             agent_impl=meta_profile.agent_impl,
             provider=meta_profile.provider,
+            model_canonical_name=meta_profile.model_canonical_name,
         )
     )
 
@@ -909,6 +910,7 @@ def main():
             agent_working_directory=run_setup.meta_agent_working_directory,
             agent_impl=agent_impl,
             provider=meta_profile.provider,
+            model_canonical_name=meta_profile.model_canonical_name,
         )
     )
 

--- a/sia/profiles.py
+++ b/sia/profiles.py
@@ -38,6 +38,13 @@ class MetaAgentProfile:
     agent_impl: str  # a registered agent impl (claude / openhands / pydantic-ai)
     model: str
     provider: Provider
+    # Canonical model id used only for SDK capability lookups (prompt caching, context window,
+    # cost), separate from ``model``, which is the routing id the gateway expects. Set this when
+    # the gateway's id differs from the vendor's own -- e.g. OpenRouter serves Anthropic's
+    # "claude-haiku-4-5" as "anthropic/claude-haiku-4.5", and capability tables key on the former.
+    # Change it whenever you change ``model``: a stale value applies the wrong model's
+    # capabilities, token limits and pricing.
+    model_canonical_name: str | None = None
 
 
 @dataclass(frozen=True)
@@ -87,6 +94,7 @@ def load_meta_agent_profile(name_or_path: str) -> MetaAgentProfile:
         agent_impl=data["agent_impl"],
         model=data["model"],
         provider=provider,
+        model_canonical_name=data.get("model_canonical_name"),
     )
     _validate_meta(profile, source)
     return profile

--- a/sia/providers.py
+++ b/sia/providers.py
@@ -32,6 +32,12 @@ class Provider:
     client_kind: str  # "anthropic" | "openai" | "google"
     base_url: str | None  # None for native endpoints; set for OpenAI-compatible providers
     api_key_env: str
+    # litellm routing prefix the openhands agent impl should use for this endpoint. Defaults to
+    # "openai" (the generic OpenAI-compatible route). Gateways with a first-class litellm provider
+    # -- e.g. "openrouter" -- should name it here: litellm then applies that provider's own request
+    # transform instead of the generic one, which preserves prompt-cache breakpoints and returns
+    # usage/cost data. See sia.agent_impls.openhands._resolve_model.
+    litellm_prefix: str | None = None
 
 
 def available_providers() -> list[str]:
@@ -64,4 +70,5 @@ def load_provider(name_or_path: str) -> Provider:
         client_kind=client_kind,
         base_url=data.get("base_url"),
         api_key_env=data["api_key_env"],
+        litellm_prefix=data.get("litellm_prefix"),
     )

--- a/tests/test_agent_impls.py
+++ b/tests/test_agent_impls.py
@@ -166,3 +166,119 @@ def test_run_agent_threads_provider_to_agent_impl():
     nebius = load_provider("nebius")
     asyncio.run(base.run_agent("m", "5", "p", "/tmp", agent_impl="capture-test", provider=nebius))
     assert captured["provider"] is nebius
+
+
+def test_openhands_model_uses_provider_declared_litellm_prefix():
+    """A provider naming its own litellm provider is routed there, not via the generic openai one."""
+    from sia.agent_impls.openhands import _resolve_model
+    from sia.providers import load_provider
+
+    openrouter = load_provider("openrouter")
+    assert openrouter.litellm_prefix == "openrouter"
+    assert _resolve_model("anthropic/claude-haiku-4.5", openrouter) == "openrouter/anthropic/claude-haiku-4.5"
+    # Already-prefixed specs are not double-prefixed.
+    assert (
+        _resolve_model("openrouter/anthropic/claude-haiku-4.5", openrouter) == "openrouter/anthropic/claude-haiku-4.5"
+    )
+    # A gateway model id that merely starts with "openai/" is a vendor namespace, not a route:
+    # it must still be prefixed (the old hardcoded guard skipped it and left it misrouted).
+    assert _resolve_model("openai/gpt-oss-120b", openrouter) == "openrouter/openai/gpt-oss-120b"
+
+    # Providers that declare no prefix keep the generic openai route, unchanged.
+    nebius = load_provider("nebius")
+    assert nebius.litellm_prefix is None
+    assert _resolve_model("moonshotai/Kimi-K2.6", nebius) == "openai/moonshotai/Kimi-K2.6"
+
+
+def test_run_agent_forwards_model_canonical_name_only_when_set():
+    """The canonical name reaches the impl when set, and is omitted otherwise.
+
+    Omitting it keeps runners registered against the older signature -- including third-party
+    impls -- working, since ``register()`` is a public extension point.
+    """
+    import asyncio
+
+    from sia.agent_impls import base
+
+    captured = {}
+
+    async def canonical_runner(model, max_turns, prompt, cwd, provider=None, model_canonical_name=None):
+        captured["canonical"] = model_canonical_name
+
+    base.register("canonical-test", canonical_runner)
+    asyncio.run(
+        base.run_agent("m", "5", "p", "/tmp", agent_impl="canonical-test", model_canonical_name="claude-haiku-4-5")
+    )
+    assert captured["canonical"] == "claude-haiku-4-5"
+
+    # Unset -> the kwarg is not passed at all, so a legacy runner signature still accepts the call.
+    legacy = {}
+
+    async def legacy_runner(model, max_turns, prompt, cwd, provider=None):
+        legacy["called"] = True
+
+    base.register("legacy-test", legacy_runner)
+    asyncio.run(base.run_agent("m", "5", "p", "/tmp", agent_impl="legacy-test"))
+    assert legacy["called"] is True
+
+
+def test_openrouter_prefix_preserves_cache_control_on_the_wire(monkeypatch):
+    """The generic openai route silently strips cache_control; the openrouter route keeps it.
+
+    This is the whole point of provider-declared prefixes: OpenHands emits the breakpoints either
+    way, so a capability flag alone proves nothing -- only the serialised body does.
+    """
+    pytest.importorskip("openhands")
+    import json
+
+    import httpx
+    from openhands.sdk import LLM
+    from openhands.sdk.llm import Message, TextContent
+
+    captured = {}
+
+    def fake_send(self, request, **kwargs):
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            request=request,
+            json={
+                "id": "x",
+                "object": "chat.completion",
+                "created": 0,
+                "model": "anthropic/claude-haiku-4.5",
+                "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12},
+            },
+        )
+
+    monkeypatch.setattr(httpx.Client, "send", fake_send)
+
+    def capture(model_spec):
+        captured.clear()
+        llm = LLM(
+            model=model_spec,
+            model_canonical_name="claude-haiku-4-5",
+            api_key="sk-not-a-real-key",
+            base_url="https://openrouter.ai/api/v1",
+            reasoning_effort=None,
+            usage_id=model_spec,
+        )
+        messages = [
+            Message(role="system", content=[TextContent(text="SYS")]),
+            Message(role="user", content=[TextContent(text="hi")]),
+        ]
+        llm.completion(messages=messages)
+        return llm, captured["body"]
+
+    llm, body = capture("openrouter/anthropic/claude-haiku-4.5")
+    assert "cache_control" in json.dumps(body["messages"]), "cache_control must survive to the wire"
+    # reasoning_effort is pinned off, so naming a litellm provider cannot silently enable thinking.
+    assert "reasoning_effort" not in body
+    # Capability lookup via the canonical name also repairs context-window detection.
+    assert llm.max_input_tokens and llm.max_output_tokens
+
+    # The generic openai route strips the markers, which is the bug being fixed. Note the
+    # capability gate reports caching active in BOTH cases -- only the payload differs.
+    _, generic_body = capture("openai/anthropic/claude-haiku-4.5")
+    assert "cache_control" not in json.dumps(generic_body["messages"])

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -101,3 +101,25 @@ def test_target_profile_file_reference(tmp_path):
     assert profile.agent_reference.kind == "file"
     assert profile.agent_reference.source is not None
     assert profile.agent_reference.source.name == "my_agent.py"
+
+
+def test_model_canonical_name_is_optional(tmp_path):
+    """A meta profile without model_canonical_name loads with None (today's behaviour)."""
+    path = _write_profile(
+        tmp_path,
+        {
+            "profile_id": "p",
+            "name": "P",
+            "agent_impl": "openhands",
+            "model": "anthropic/claude-haiku-4.5",
+            "provider_id": "openrouter",
+        },
+    )
+    assert load_meta_agent_profile(path).model_canonical_name is None
+
+
+def test_model_canonical_name_is_read_when_present():
+    """The bundled OpenRouter meta profile carries the vendor's canonical id."""
+    profile = load_meta_agent_profile("openrouter-meta")
+    assert profile.model == "anthropic/claude-haiku-4.5"
+    assert profile.model_canonical_name == "claude-haiku-4-5"

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -78,3 +78,23 @@ def test_user_dir_overrides_bundled(tmp_path, monkeypatch):
     )
     monkeypatch.setenv("SIA_PROVIDERS_DIR", str(providers_dir))
     assert load_provider("nebius").base_url == "https://override/v1"
+
+
+def test_litellm_prefix_is_optional_and_defaults_to_none(tmp_path):
+    """Providers omitting litellm_prefix keep the generic openai route."""
+    path = tmp_path / "custom.json"
+    path.write_text(
+        json.dumps(
+            {
+                "provider_id": "custom",
+                "name": "Custom",
+                "client_kind": "openai",
+                "base_url": "https://example.test/v1",
+                "api_key_env": "CUSTOM_API_KEY",
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert load_provider(str(path)).litellm_prefix is None
+    # The bundled OpenRouter provider names its own litellm provider.
+    assert load_provider("openrouter").litellm_prefix == "openrouter"


### PR DESCRIPTION
> Builds on #53 (now merged); rebased onto `main`.

## Summary

Prompt caching was silently dead on **every** OpenAI-compatible gateway, and the meta agent's
context window and cost were undetectable. A gen-0 run on OpenRouter cost **$0.63** with a
**0.00% cache hit rate** on every turn — 400K cumulative input tokens re-sent across 20 turns.

Two independent causes:

1. **litellm strips the breakpoints.** `_resolve_model` hardcoded an `openai/` prefix, so litellm resolved `custom_llm_provider="openai"` and `OpenAIGPTConfig.remove_cache_control_flag_from_messages_and_tools` (`litellm/llms/openai/chat/gpt_transformation.py:400-420`, called unconditionally at `:438`) recursively deleted every `cache_control` key before the request was serialised. OpenHands emitted them correctly; litellm dropped them with no error and no warning.
2. **The capability gate never fired.** OpenHands keys `PROMPT_CACHE_MODELS` on the vendor's hyphenated id (`claude-haiku-4-5`), but a gateway routes by its own id (`anthropic/claude-haiku-4.5`). The substring match failed, and litellm could not map the model at all — leaving `max_input_tokens` and `max_output_tokens` as `None` and cost reported as `$0.00`.

Both become configuration rather than code, so a new gateway or model needs no code change.

| | before | after |
|---|---|---|
| `cache_control` on the wire | stripped | present |
| `max_input_tokens` | `None` | 200000 |
| `max_output_tokens` | `None` | 64000 |
| cost per turn | `$0.00` | real |

## Type of change

Select all that apply:

- [x] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] New or updated task
- [ ] Evaluation change
- [x] Provider/model configuration
- [ ] Security-sensitive change
- [ ] Refactor / maintenance
- [ ] Other

## Related issue

Closes #

## What changed

- **`sia/providers.py`** — `Provider` gains optional `litellm_prefix` (default `"openai"`). Providers that omit it behave byte-identically to before.
- **`sia/defaults/providers/openrouter.json`** — sets `"litellm_prefix": "openrouter"`, so litellm applies `OpenrouterConfig`, which preserves `cache_control` (`transformation.py:91-102`), hoists tool-message markers into content blocks as OpenRouter requires (`:103-145`), and adds `usage: {include: true}` (`:167-169`).
- **`sia/profiles.py`** — `MetaAgentProfile` gains optional `model_canonical_name`, used **only** for SDK capability lookups while `model` stays the routing id.
- **`sia/defaults/profiles/openrouter-meta.json`** — sets `"model_canonical_name": "claude-haiku-4-5"`.
- **`sia/agent_impls/openhands.py`** — `_resolve_model` uses the provider-declared prefix; the canonical name is passed to `LLM(...)`; **`reasoning_effort` is pinned to `None`** (see below); a warning fires if the installed SDK ignored the canonical name.
- **`sia/agent_impls/base.py`, `sia/orchestrator.py`** — thread the canonical name from the profile to the impl.
- **`docs/configuration.md`** — documents both fields and corrects the OpenRouter section.

### Why `reasoning_effort=None`

Naming a gateway's litellm provider has a side effect that has nothing to do with caching: the SDK
defaults `reasoning_effort` to `"high"` (`llm.py:358-364`) and only sends it when litellm reports
the provider reasoning-capable — true for `openrouter/…`, false for `openai/…`. Captured bodies,
same messages, only the prefix differing:

```
openai/…      {'model': 'anthropic/claude-haiku-4.5'}
openrouter/…  {'model': ..., 'max_completion_tokens': 64000,
               'reasoning_effort': 'high', 'usage': {'include': True}}
```

That is extended thinking at high budget — more output tokens, higher latency, different tool
behaviour. Shipping it inside a caching fix would make any measured cost delta uninterpretable, so
it is pinned off. Enabling thinking should be a separate change with its own before/after eval.

### Backward compatibility

The canonical name is forwarded **only when set**, so runners registered against the older
signature keep working — `register()` is a documented extension point (`base.py:5-9`) and
`AgentRunner` is `Callable[..., Awaitable[None]]`, so no type checker would catch a break. When the
value *is* set and a runner cannot accept it, the `TypeError` is loud rather than a silently
ignored capability.

## How I tested this

```bash
python -m pytest tests/ -v          # 139 passed (133 before, 6 new)
ruff check sia/ tests/              # All checks passed!
ruff format --check sia/ tests/     # 51 files already formatted
ty check sia/                       # All checks passed!
```

New tests:

- `test_openrouter_prefix_preserves_cache_control_on_the_wire` — monkeypatches the HTTP transport and asserts `cache_control` is present in the **serialised request body** under `openrouter/` and absent under `openai/`, that `reasoning_effort` is not sent, and that the token limits are populated. Asserting on the capability flag alone would prove nothing: it reports caching active in *both* cases — only the payload differs. No network, no spend.
- `test_openhands_model_uses_provider_declared_litellm_prefix` — covers the new prefix, no double-prefixing, that `nebius` is unchanged, and that `openai/gpt-oss-120b` on a gateway is now correctly prefixed (the old hardcoded `startswith("openai/")` guard skipped it and left it misrouted — a latent bug this fixes).
- `test_run_agent_forwards_model_canonical_name_only_when_set` — covers both branches of the conditional forwarding, including a legacy runner signature.
- Optional-field loading tests for both `litellm_prefix` and `model_canonical_name`.

The wire-capture test uses `pytest.importorskip("openhands")`, matching the existing `pydantic_ai`
test, so **it skips in CI** where optional SDKs are not installed. It runs for anyone following the
CONTRIBUTING dev setup.

**Not yet measured live.** The predicted saving is inferred from the payload and the published
cache multipliers (writes 1.25×, reads 0.1×), not observed on a real run — the test key's credit
cap could not fund a second gen-0. Someone should confirm a non-zero cache hit rate and the actual
dollar delta before we quote a number.

## Known limitation, deliberately out of scope

`sia/context_manager.py:155-161` calls `run_agent` **without a provider**, so the per-generation
summariser resolves `anthropic/claude-haiku-4.5` with no base_url and `sia/api_keys.py:21` reaches
for `ANTHROPIC_API_KEY`. An OpenRouter-only user gets a 401 against `api.anthropic.com`, and the
failure is swallowed (`context_manager.py:167-172` returns `None`), so generation summaries go
silently missing. That predates this PR and needs `ContextManager` to receive the profile; flagging
it here so the summariser still being empty is not mistaken for this fix not working.

## Security and privacy checklist

- [x] This change does not log API keys, secrets, private task data, or generated credentials.
- [x] This change does not weaken sandboxing, subprocess isolation, or task data boundaries.
- [ ] Security-sensitive behavior is explained in the PR description.
- [x] Not applicable.

## Documentation checklist

- [x] I updated README.md, CONTRIBUTING.md, SECURITY.md, or docs files as needed.
- [x] I added or updated examples where helpful.
- [ ] Documentation is not needed for this change.

## Contributor checklist

- [x] I ran the relevant tests.
- [x] I ran linting and formatting checks.
- [x] I kept the PR focused on one logical change.
- [x] I reviewed my own diff before requesting review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HPkffXZbzVPFLiaEy2PRfB
