### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sia-agent"
-version = "0.5.1"
+version = "0.6.0"
 description = "SIA: Self-Improving AI framework"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Bumps `pyproject.toml` version `0.5.1` → `0.6.0` so the `v0.6.0` tag can be pushed and the PyPI publish workflow can run (it verifies tag == package version).

Minor bump because a new feature landed since `v0.5.1`.

## Since v0.5.1
- feat: add OpenRouter provider and profiles (#53)
- fix: route gateways via their own litellm provider so prompt caching works (#55)
- fix: harden OpenRouter target runs (#48)
- fix(gpqa): write evaluator output to results.json (#31)
- fix(ci): install package in lint job so ty resolves imports (#49)
- docs: evaluator design checklist (#33), code of conduct (#45), README/CONTRIBUTING updates, issue/PR templates

## After merge
Tag `v0.6.0` on main to trigger `.github/workflows/publish.yml` (test matrix → build → PyPI).

Local `pytest tests/ -v`: 139 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTMAaF6uZTeztfUV1m52PC