### PR TITLE
fix(gpqa): abstain instead of guessing a letter from anywhere in the reply

### DIFF
--- a/sia/tasks/gpqa/reference/reference_target_agent.py
+++ b/sia/tasks/gpqa/reference/reference_target_agent.py
@@ -103,7 +103,23 @@ def parse_answer_letter(model_answer_raw: str) -> str:
     if match:
         return match.group(1)
 
-    return next((letter for letter in "ABCD" if letter in answer), "")
+    # A few more shapes the model actually produces: "FINAL ANSWER - B",
+    # "**C**", "(D)", or a reply that is nothing but the letter and punctuation.
+    for pattern in (r'FINAL ANSWER\s*[:\-]?\s*\(?\*{0,2}([ABCD])',
+                    r'\*\*\s*([ABCD])\s*\*\*',
+                    r'\(\s*([ABCD])\s*\)',
+                    r'^\W*([ABCD])\W*$'):
+        match = re.search(pattern, answer, re.MULTILINE)
+        if match:
+            return match.group(1)
+
+    # No stated answer. Return "" rather than scanning the text for a bare
+    # letter: `next(l for l in "ABCD" if l in answer)` matches letters inside
+    # ordinary words, so any reply containing "A" -- including a refusal or an
+    # error message -- scores as "A". That silently converts unanswered items
+    # into confident wrong answers, and the harness cannot tell the difference
+    # afterwards. An empty string is a measurable abstention; a guess is not.
+    return ""
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## The problem

`parse_answer_letter` ends with:

```python
return next((letter for letter in "ABCD" if letter in answer), "")
```

This returns the first of A/B/C/D found **anywhere** in the reply, including inside ordinary words. So any reply containing the letter "A" scores as `"A"`:

| reply | scored as | actually |
|---|---|---|
| `"Actually this one is tricky, I'm unsure"` | **A** | no answer given |
| `"I cannot determine the answer."` | **A** | no answer given |
| `"Error: rate limited"` | **A** | infrastructure failure |

On one 198-question GPQA Diamond run, this fallback decided **163 of the 198 answers**.

The consequence is not just noise. It silently converts abstentions and infrastructure failures into confident answers, so the evaluator cannot afterwards distinguish "the model didn't answer" from "the model answered and was wrong". Since the accuracy number is the only signal the feedback agent receives, that distinction matters: the two call for opposite fixes.

## The change

1. Add the response shapes the model actually emits and that the current chain misses: `**C**`, `(D)`, `Final answer - B`, and a reply that is just the letter and punctuation.
2. Return `""` when none match, instead of scanning for a bare letter.

Every existing extraction path (JSON block, exact letter, `ANSWER IS X`, `ANSWER: X`) is untouched and tried first.

## Compatibility

The retry guard in `get_answer_async` is `if model_answer not in "ABCD"`. In Python `"" in "ABCD"` is `True`, so an abstention does not raise and control flow is unchanged.

**This will lower apparent accuracy on some runs**, and that is the point: it stops crediting lucky substring matches. Runs that previously reported zero unanswered items may now report some. That is the abstention becoming visible rather than appearing as wrong answers.

## Verification

11/11 cases, covering each existing path (unchanged), each new pattern, and each abstention case.
