### PR TITLE
fix(orchestrator): allow an out-of-process deadline on the target agent

### DIFF
--- a/sia/orchestrator.py
+++ b/sia/orchestrator.py
@@ -47,6 +47,7 @@ import glob
 import json
 import os
 import subprocess
+import threading
 import time
 import traceback
 from datetime import datetime
@@ -294,7 +295,18 @@ def _stream_to_log(cmd: list[str], stdout_log_file: str, env: dict | None = None
     Returns the process exit code. This is the single place the target agent
     subprocess is launched; the Popen call stays in this module's namespace so it
     remains patchable in tests.
+
+    If ``SIA_TARGET_TIMEOUT`` is set to a positive number of seconds, the process
+    is killed after that long. The deadline is enforced from outside the process
+    because a target agent that deadlocks cannot enforce its own: an agent we
+    watched set three internal timeouts and still hung, since all three lived
+    inside the loop that had stopped. Unset (the default), behaviour is unchanged.
     """
+    try:
+        deadline = float(os.environ.get("SIA_TARGET_TIMEOUT", "") or 0)
+    except ValueError:
+        deadline = 0.0
+
     with open(stdout_log_file, "w", encoding="utf-8") as log_fh:
         process = subprocess.Popen(
             cmd,
@@ -303,10 +315,29 @@ def _stream_to_log(cmd: list[str], stdout_log_file: str, env: dict | None = None
             text=True,
             env=env,
         )
-        for line in process.stdout:
-            print(line, end="")
-            log_fh.write(line)
-        return process.wait()
+
+        timer = None
+        if deadline > 0:
+            def _kill_hung() -> None:
+                if process.poll() is None:
+                    msg = (f"\n[sia] target agent exceeded SIA_TARGET_TIMEOUT="
+                           f"{deadline:.0f}s; terminating.\n")
+                    print(msg, end="")
+                    log_fh.write(msg)
+                    process.kill()
+
+            timer = threading.Timer(deadline, _kill_hung)
+            timer.daemon = True
+            timer.start()
+
+        try:
+            for line in process.stdout:
+                print(line, end="")
+                log_fh.write(line)
+            return process.wait()
+        finally:
+            if timer is not None:
+                timer.cancel()
 
 
 def _run_target_agent_sandboxed(


### PR DESCRIPTION
## The problem

SIA bounds every subprocess except the one that matters most:

```python
SHELL_TIMEOUT:  int = 30
EVAL_TIMEOUT:   int = 600
DOCKER_TIMEOUT: int = 3600
```

But `_stream_to_log`, the single place the target agent is launched, ends with:

```python
for line in process.stdout:
    ...
return process.wait()          # no timeout
```

A bare `wait()` blocks indefinitely. `timeout=` appears exactly once in `orchestrator.py`, on the evaluator. So a target agent that hangs on a network call stalls **the whole run**, not just its own generation.

## Why the agent can't bound itself

This came up in practice. One generation wrote an agent that set *three* internal timeouts and still deadlocked, because all three lived inside the event loop that had stopped. A deadline enforced by the thing being timed is not a deadline. It has to be held outside the process.

## The change

An optional `SIA_TARGET_TIMEOUT` (seconds).

- **Unset (default):** behaviour is byte-for-byte unchanged. `129 passed, 1 skipped`.
- **Set:** a daemon timer kills the process at the deadline and writes the reason into the run log, so the generation is attributable afterwards rather than just missing.
- **Malformed value:** ignored, no raise.

Roughly 25 lines, entirely inside `_stream_to_log`. The `Popen` call stays in this module's namespace, so it remains patchable in tests as the docstring promises.

## Verification

| scenario | result |
|---|---|
| unset + fast process | `rc=0` in 0.0s, not killed |
| `=3` + process sleeping 60s | killed at 3.0s, `rc=-9` |
| `=3` + fast process | `rc=0`, not killed |
| `="not-a-number"` | ignored, no crash |
| upstream suite, unset | 129 passed, 1 skipped |

The reason is written to the log, so a killed generation is distinguishable from a crashed one.
